### PR TITLE
Add checkbox component with shadcn styling

### DIFF
--- a/src/starui/registry/components/button.py
+++ b/src/starui/registry/components/button.py
@@ -1,7 +1,7 @@
 from typing import Any, Literal
 
 from starhtml import FT
-from starhtml import Button as BaseButton
+from starhtml import Button as HTMLButton
 
 from .utils import cn, cva
 
@@ -46,4 +46,4 @@ def Button(
     **attrs: Any,
 ) -> FT:
     classes = cn(button_variants(variant=variant, size=size), class_name, cls)
-    return BaseButton(*children, cls=classes, disabled=disabled, type=type, **attrs)
+    return HTMLButton(*children, cls=classes, disabled=disabled, type=type, **attrs)

--- a/src/starui/registry/components/checkbox.py
+++ b/src/starui/registry/components/checkbox.py
@@ -1,9 +1,9 @@
 from typing import Any
 from uuid import uuid4
 
-from starhtml import FT, Div, Icon, Input, Label, P, Span
-from starhtml import Button as HTMLButton
-from starhtml.datastar import ds_class, ds_on_click, ds_signals
+from starhtml import FT, Div, Icon, Label, P, Span
+from starhtml import Input as HTMLInput
+from starhtml.datastar import ds_bind, ds_class, ds_signals
 
 from .utils import cn
 
@@ -17,44 +17,50 @@ def Checkbox(
     required: bool = False,
     class_name: str = "",
     cls: str = "",
+    indicator_cls: str = "",
     **attrs: Any,
 ) -> FT:
     signal = signal or f"checkbox_{str(uuid4())[:8]}"
-    state_expr = f"${signal} ? 'checked' : 'unchecked'"
 
-    return HTMLButton(
-        Span(
-            Icon("lucide:check", cls="size-3.5"),
-            ds_class(**{"opacity-100": f"${signal}", "opacity-0": f"!${signal}"}),
-            data_state=state_expr,
-            data_slot="checkbox-indicator",
-            cls="flex items-center justify-center text-current transition-none",
-            style="pointer-events: none;",
-        ),
-        Input(
+    return Div(
+        HTMLInput(
+            ds_bind(signal),
             type="checkbox",
             name=name,
             value=value or "on",
-            checked=f"${signal}",
             disabled=disabled,
             required=required,
-            tabindex="-1",
-            cls="absolute opacity-0 pointer-events-none",
+            data_slot="checkbox",
+            cls=cn(
+                "peer appearance-none size-4 shrink-0 rounded-[4px] border shadow-xs transition-all outline-none",
+                "border-input bg-background dark:bg-input/30",
+                "checked:bg-foreground checked:border-foreground",
+                "dark:checked:bg-foreground dark:checked:border-foreground",
+                "focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px]",
+                "aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40",
+                "aria-invalid:border-destructive aria-invalid:checked:border-destructive",
+                "disabled:cursor-not-allowed disabled:opacity-50",
+                class_name,
+                cls,
+            ),
             **attrs,
         ),
-        ds_signals(**{signal: checked or False}),
-        ds_on_click(f"${signal} = !${signal}"),
-        data_state=state_expr,
-        data_slot="checkbox",
-        type="button",
-        role="checkbox",
-        aria_checked=f"${signal}",
-        disabled=disabled,
-        cls=cn(
-            "peer border-input dark:bg-input/30 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground dark:data-[state=checked]:bg-primary data-[state=checked]:border-primary focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive size-4 shrink-0 rounded-[4px] border shadow-xs transition-shadow outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
-            class_name,
-            cls,
+        Span(
+            Icon("lucide:check"),
+            ds_class(
+                **{
+                    "opacity-100": f"${signal}",
+                    "opacity-0": f"!${signal}",
+                }
+            ),
+            data_slot="checkbox-indicator",
+            cls=cn(
+                "absolute inset-0 flex items-center justify-center text-background text-sm transition-opacity pointer-events-none",
+                indicator_cls,
+            ),
         ),
+        ds_signals(**{signal: checked or False}),
+        cls="relative inline-block",
     )
 
 
@@ -72,6 +78,7 @@ def CheckboxWithLabel(
     cls: str = "",
     label_cls: str = "",
     checkbox_cls: str = "",
+    indicator_cls: str = "",
     **attrs: Any,
 ) -> FT:
     checkbox_id = f"checkbox_{str(uuid4())[:8]}"
@@ -88,14 +95,17 @@ def CheckboxWithLabel(
                 id=checkbox_id,
                 aria_invalid="true" if error_text else None,
                 cls=checkbox_cls,
+                indicator_cls=indicator_cls,
             ),
             Div(
                 Label(
                     label,
-                    required and Span(" *", cls="text-destructive") or "",
+                    required and Span(" *", cls="text-destructive") or None,
                     for_=checkbox_id,
                     cls=cn(
-                        "flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
+                        "flex items-center gap-2 text-sm leading-none font-medium select-none",
+                        "group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50",
+                        "peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
                         "opacity-50 cursor-not-allowed" if disabled else "",
                         label_cls,
                     ),

--- a/src/starui/registry/components/checkbox.py
+++ b/src/starui/registry/components/checkbox.py
@@ -53,7 +53,7 @@ def Checkbox(
         cls=cn(
             "peer border-input dark:bg-input/30 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground dark:data-[state=checked]:bg-primary data-[state=checked]:border-primary focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive size-4 shrink-0 rounded-[4px] border shadow-xs transition-shadow outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
             class_name,
-            cls
+            cls,
         ),
     )
 
@@ -101,13 +101,15 @@ def CheckboxWithLabel(
                     ),
                     data_slot="label",
                 ),
-                helper_text and P(
+                helper_text
+                and P(
                     helper_text,
                     cls=cn(
                         "text-muted-foreground text-sm",
-                        "opacity-50" if disabled else ""
-                    )
-                ) or None,
+                        "opacity-50" if disabled else "",
+                    ),
+                )
+                or None,
                 cls="grid gap-1.5" if helper_text else None,
             ),
             cls="flex items-start gap-3",

--- a/src/starui/registry/components/checkbox.py
+++ b/src/starui/registry/components/checkbox.py
@@ -1,0 +1,118 @@
+from typing import Any
+from uuid import uuid4
+
+from starhtml import FT, Div, Icon, Input, Label, P, Span
+from starhtml import Button as HTMLButton
+from starhtml.datastar import ds_class, ds_on_click, ds_signals
+
+from .utils import cn
+
+
+def Checkbox(
+    checked: bool | None = None,
+    name: str | None = None,
+    value: str | None = None,
+    signal: str | None = None,
+    disabled: bool = False,
+    required: bool = False,
+    class_name: str = "",
+    cls: str = "",
+    **attrs: Any,
+) -> FT:
+    signal = signal or f"checkbox_{str(uuid4())[:8]}"
+    state_expr = f"${signal} ? 'checked' : 'unchecked'"
+
+    return HTMLButton(
+        Span(
+            Icon("lucide:check", cls="size-3.5"),
+            ds_class(**{"opacity-100": f"${signal}", "opacity-0": f"!${signal}"}),
+            data_state=state_expr,
+            data_slot="checkbox-indicator",
+            cls="flex items-center justify-center text-current transition-none",
+            style="pointer-events: none;",
+        ),
+        Input(
+            type="checkbox",
+            name=name,
+            value=value or "on",
+            checked=f"${signal}",
+            disabled=disabled,
+            required=required,
+            tabindex="-1",
+            cls="absolute opacity-0 pointer-events-none",
+            **attrs,
+        ),
+        ds_signals(**{signal: checked or False}),
+        ds_on_click(f"${signal} = !${signal}"),
+        data_state=state_expr,
+        data_slot="checkbox",
+        type="button",
+        role="checkbox",
+        aria_checked=f"${signal}",
+        disabled=disabled,
+        cls=cn(
+            "peer border-input dark:bg-input/30 data-[state=checked]:bg-primary data-[state=checked]:text-primary-foreground dark:data-[state=checked]:bg-primary data-[state=checked]:border-primary focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive size-4 shrink-0 rounded-[4px] border shadow-xs transition-shadow outline-none focus-visible:ring-[3px] disabled:cursor-not-allowed disabled:opacity-50",
+            class_name,
+            cls
+        ),
+    )
+
+
+def CheckboxWithLabel(
+    label: str,
+    checked: bool | None = None,
+    name: str | None = None,
+    value: str | None = None,
+    signal: str | None = None,
+    helper_text: str | None = None,
+    error_text: str | None = None,
+    disabled: bool = False,
+    required: bool = False,
+    class_name: str = "",
+    cls: str = "",
+    label_cls: str = "",
+    checkbox_cls: str = "",
+    **attrs: Any,
+) -> FT:
+    checkbox_id = f"checkbox_{str(uuid4())[:8]}"
+
+    return Div(
+        Div(
+            Checkbox(
+                checked=checked,
+                name=name,
+                value=value,
+                signal=signal,
+                disabled=disabled,
+                required=required,
+                id=checkbox_id,
+                aria_invalid="true" if error_text else None,
+                cls=checkbox_cls,
+            ),
+            Div(
+                Label(
+                    label,
+                    required and Span(" *", cls="text-destructive") or "",
+                    for_=checkbox_id,
+                    cls=cn(
+                        "flex items-center gap-2 text-sm leading-none font-medium select-none group-data-[disabled=true]:pointer-events-none group-data-[disabled=true]:opacity-50 peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
+                        "opacity-50 cursor-not-allowed" if disabled else "",
+                        label_cls,
+                    ),
+                    data_slot="label",
+                ),
+                helper_text and P(
+                    helper_text,
+                    cls=cn(
+                        "text-muted-foreground text-sm",
+                        "opacity-50" if disabled else ""
+                    )
+                ) or None,
+                cls="grid gap-1.5" if helper_text else None,
+            ),
+            cls="flex items-start gap-3",
+        ),
+        error_text and P(error_text, cls="text-sm text-destructive mt-1.5") or None,
+        cls=cn(class_name, cls),
+        **attrs,
+    )

--- a/src/starui/registry/components/input.py
+++ b/src/starui/registry/components/input.py
@@ -1,7 +1,7 @@
 from typing import Literal
 
 from starhtml import FT, Div, Label, P, Span
-from starhtml import Input as BaseInput
+from starhtml import Input as HTMLInput
 
 from .utils import cn
 
@@ -84,7 +84,7 @@ def Input(
         **attrs,
     }
 
-    return BaseInput(*datastar_attrs, **input_attrs)
+    return HTMLInput(*datastar_attrs, **input_attrs)
 
 
 def InputWithLabel(

--- a/src/starui/registry/components/tabs.py
+++ b/src/starui/registry/components/tabs.py
@@ -2,7 +2,7 @@ from itertools import count
 from typing import Any, Literal
 
 from starhtml import FT, Div
-from starhtml import Button as BaseButton
+from starhtml import Button as HTMLButton
 from starhtml.datastar import ds_on_click, ds_show, ds_signals
 
 from .utils import cn
@@ -102,7 +102,7 @@ def TabsTrigger(
             ),
         }
 
-        return BaseButton(
+        return HTMLButton(
             *children,
             ds_on_click(f"${signal_value} = '{value}'"),
             disabled=disabled,

--- a/test_sandbox/app.py
+++ b/test_sandbox/app.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 # Import starhtml first, then override with our custom components
 from starhtml import *
+
 # Import all registry components at once (this will override starhtml components)
 from registry_loader import *
 
@@ -159,10 +160,14 @@ def index():
                     TabsContent(
                         Div(
                             H3("Preview Content", cls="text-lg font-semibold mb-2"),
-                            P("This is the preview tab content with the default boxed style."),
-                            Button("Action in Preview", variant="secondary", cls="mt-4"),
+                            P(
+                                "This is the preview tab content with the default boxed style."
+                            ),
+                            Button(
+                                "Action in Preview", variant="secondary", cls="mt-4"
+                            ),
                         ),
-                        value="preview"
+                        value="preview",
                     ),
                     TabsContent(
                         Div(
@@ -170,11 +175,11 @@ def index():
                             Pre(
                                 Code(
                                     "# Example code\ndef hello_world():\n    print('Hello, World!')",
-                                    cls="block p-4 bg-muted rounded"
+                                    cls="block p-4 bg-muted rounded",
                                 )
                             ),
                         ),
-                        value="code"
+                        value="code",
                     ),
                     TabsContent(
                         Div(
@@ -183,14 +188,14 @@ def index():
                             Div(
                                 Label("Enable notifications", for_="notifications"),
                                 Input(type="checkbox", id="notifications", cls="ml-2"),
-                                cls="flex items-center gap-2 mt-4"
+                                cls="flex items-center gap-2 mt-4",
                             ),
                         ),
-                        value="settings"
+                        value="settings",
                     ),
                     default_value="preview",
                     variant="default",
-                    cls="mb-8"
+                    cls="mb-8",
                 ),
             ),
             # Tabs example - Plain variant (text style)
@@ -209,11 +214,15 @@ def index():
                             P("Manage your account settings and preferences."),
                             Div(
                                 Label("Username", for_="username"),
-                                Input(id="username", placeholder="Enter username", cls="max-w-sm"),
-                                cls="space-y-2 mt-4"
+                                Input(
+                                    id="username",
+                                    placeholder="Enter username",
+                                    cls="max-w-sm",
+                                ),
+                                cls="space-y-2 mt-4",
                             ),
                         ),
-                        value="account"
+                        value="account",
                     ),
                     TabsContent(
                         Div(
@@ -221,25 +230,25 @@ def index():
                             P("Update your password and security settings."),
                             Button("Change Password", variant="outline", cls="mt-4"),
                         ),
-                        value="password"
+                        value="password",
                     ),
                     TabsContent(
                         Div(
                             H3("Team Members", cls="text-lg font-semibold mb-2"),
                             P("Manage your team and collaborate with others."),
                         ),
-                        value="team"
+                        value="team",
                     ),
                     TabsContent(
                         Div(
                             H3("Billing Information", cls="text-lg font-semibold mb-2"),
                             P("View and manage your subscription and payment methods."),
                         ),
-                        value="billing"
+                        value="billing",
                     ),
                     default_value="account",
                     variant="plain",
-                    cls="mb-8"
+                    cls="mb-8",
                 ),
             ),
             # Sheet example
@@ -295,12 +304,21 @@ def index():
                         Div(
                             Div(
                                 Label("Name", for_="dialog-name"),
-                                Input(id="dialog-name", placeholder="Your name", cls="mt-1"),
+                                Input(
+                                    id="dialog-name",
+                                    placeholder="Your name",
+                                    cls="mt-1",
+                                ),
                                 cls="space-y-2",
                             ),
                             Div(
                                 Label("Email", for_="dialog-email"),
-                                Input(id="dialog-email", type="email", placeholder="your@email.com", cls="mt-1"),
+                                Input(
+                                    id="dialog-email",
+                                    type="email",
+                                    placeholder="your@email.com",
+                                    cls="mt-1",
+                                ),
                                 cls="space-y-2",
                             ),
                             cls="grid gap-4 py-4",
@@ -319,7 +337,9 @@ def index():
             Div(
                 H2("Alert Dialog", cls="text-2xl font-semibold mb-4"),
                 Dialog(
-                    trigger=DialogTrigger("Delete Account", ref_id="delete-dialog", variant="destructive"),
+                    trigger=DialogTrigger(
+                        "Delete Account", ref_id="delete-dialog", variant="destructive"
+                    ),
                     content=DialogContent(
                         DialogHeader(
                             DialogTitle("Are you absolutely sure?"),
@@ -343,31 +363,38 @@ def index():
                 H2("Checkboxes", cls="text-2xl font-semibold mb-4"),
                 Div(
                     CheckboxWithLabel(
-                        "Accept terms and conditions",
-                        signal="terms",
-                        required=True
+                        "Accept terms and conditions", signal="terms", required=True
                     ),
                     CheckboxWithLabel(
                         "Subscribe to newsletter",
                         signal="newsletter",
-                        helper_text="Get weekly updates about new features"
+                        helper_text="Get weekly updates about new features",
                     ),
                     CheckboxWithLabel(
-                        "Enable notifications",
-                        signal="notifications",
-                        checked=True
+                        "Enable notifications", signal="notifications", checked=True
                     ),
                     CheckboxWithLabel(
                         "Disabled option",
                         disabled=True,
-                        helper_text="This option is currently unavailable"
+                        helper_text="This option is currently unavailable",
                     ),
                     CheckboxWithLabel(
                         "Error state example",
                         signal="error_checkbox",
-                        error_text="This field is required"
+                        error_text="This field is required",
                     ),
-                    cls="space-y-4 mb-8"
+                    # Custom styled checkbox with blue background
+                    Div(
+                        CheckboxWithLabel(
+                            "Custom blue checkbox",
+                            signal="blue_checkbox",
+                            helper_text="With custom blue styling when checked",
+                            checkbox_cls="checked:!bg-blue-600 checked:!border-blue-600 dark:checked:!bg-blue-700 dark:checked:!border-blue-700",
+                            indicator_cls="!text-white",
+                        ),
+                        cls="p-4 border rounded-lg",
+                    ),
+                    cls="space-y-4 mb-8",
                 ),
             ),
             # Interactive counter with Datastar

--- a/test_sandbox/app.py
+++ b/test_sandbox/app.py
@@ -338,6 +338,38 @@ def index():
                 ),
                 cls="mb-8",
             ),
+            # Checkbox examples
+            Div(
+                H2("Checkboxes", cls="text-2xl font-semibold mb-4"),
+                Div(
+                    CheckboxWithLabel(
+                        "Accept terms and conditions",
+                        signal="terms",
+                        required=True
+                    ),
+                    CheckboxWithLabel(
+                        "Subscribe to newsletter",
+                        signal="newsletter",
+                        helper_text="Get weekly updates about new features"
+                    ),
+                    CheckboxWithLabel(
+                        "Enable notifications",
+                        signal="notifications",
+                        checked=True
+                    ),
+                    CheckboxWithLabel(
+                        "Disabled option",
+                        disabled=True,
+                        helper_text="This option is currently unavailable"
+                    ),
+                    CheckboxWithLabel(
+                        "Error state example",
+                        signal="error_checkbox",
+                        error_text="This field is required"
+                    ),
+                    cls="space-y-4 mb-8"
+                ),
+            ),
             # Interactive counter with Datastar
             Div(
                 H2("Interactive Counter (Datastar)", cls="text-2xl font-semibold mb-4"),


### PR DESCRIPTION
## Summary
- Add Checkbox component with Datastar reactive signals
- Add CheckboxWithLabel composition component
- Includes helper text, error states, and disabled styling
- Follows StarUI patterns and matches shadcn/ui design

## Test plan
- ✅ All existing tests pass
- ✅ Ruff linting passes
- ✅ Pyright type checking passes
- ✅ Package builds successfully
- ✅ Visual testing in test_sandbox shows proper alignment and styling
- ✅ Interactive testing confirms signal reactivity works correctly