### PR TITLE
Add radio group component with semantic HTML improvements

### DIFF
--- a/src/starui/registry/components/badge.py
+++ b/src/starui/registry/components/badge.py
@@ -1,6 +1,7 @@
 from typing import Literal
 
 from starhtml import FT, A, Span
+from starhtml import Button as HTMLButton
 
 from .utils import cn, cva
 
@@ -38,12 +39,11 @@ def Badge(
         return A(*children, href=href, cls=classes, data_slot="badge", **attrs)
 
     if clickable:
-        return Span(
+        return HTMLButton(
             *children,
             cls=cn(classes, "cursor-pointer"),
             data_slot="badge",
-            tabindex="0",
-            role="button",
+            type="button",
             **attrs,
         )
 

--- a/src/starui/registry/components/card.py
+++ b/src/starui/registry/components/card.py
@@ -1,6 +1,10 @@
-from starhtml import FT, Div
+from typing import Literal
+
+from starhtml import FT, H1, H2, H3, H4, H5, H6, Div, P
 
 from .utils import cn
+
+HeadingLevel = Literal["h1", "h2", "h3", "h4", "h5", "h6"]
 
 
 def Card(
@@ -33,12 +37,24 @@ def CardHeader(
 
 def CardTitle(
     *children,
+    level: HeadingLevel = "h3",
     class_name: str = "",
     cls: str = "",
     **attrs,
 ) -> FT:
     classes = cn("leading-none font-semibold", class_name, cls)
-    return Div(*children, cls=classes, data_slot="card-title", **attrs)
+
+    heading_components = {
+        "h1": H1,
+        "h2": H2,
+        "h3": H3,
+        "h4": H4,
+        "h5": H5,
+        "h6": H6,
+    }
+
+    Heading = heading_components[level]
+    return Heading(*children, cls=classes, data_slot="card-title", **attrs)
 
 
 def CardDescription(
@@ -48,7 +64,7 @@ def CardDescription(
     **attrs,
 ) -> FT:
     classes = cn("text-muted-foreground text-sm", class_name, cls)
-    return Div(*children, cls=classes, data_slot="card-description", **attrs)
+    return P(*children, cls=classes, data_slot="card-description", **attrs)
 
 
 def CardAction(

--- a/src/starui/registry/components/radio_group.py
+++ b/src/starui/registry/components/radio_group.py
@@ -1,0 +1,181 @@
+from itertools import count
+from typing import Any
+from uuid import uuid4
+
+from starhtml import FT, Div, Label, P, Span
+from starhtml import Input as HTMLInput
+from starhtml.datastar import ds_class, ds_on_change, ds_signals
+
+from .utils import cn
+
+_radio_group_ids = count(1)
+
+
+def RadioGroup(
+    *children: Any,
+    value: str | None = None,
+    signal: str = "",
+    disabled: bool = False,
+    required: bool = False,
+    class_name: str = "",
+    cls: str = "",
+    **attrs: Any,
+) -> FT:
+    signal = signal or f"radio_{next(_radio_group_ids)}"
+    group_name = f"radio_group_{signal}"
+
+    processed_children = [
+        child._inject_signal(signal, group_name, value)
+        if hasattr(child, "_inject_signal")
+        else child
+        for child in children
+    ]
+
+    return Div(
+        *processed_children,
+        ds_signals(**{signal: value or ""}),
+        cls=cn("grid gap-2", class_name, cls),
+        data_slot="radio-group",
+        data_radio_signal=signal,
+        data_radio_name=group_name,
+        role="radiogroup",
+        aria_required="true" if required else None,
+        **attrs,
+    )
+
+
+def RadioGroupItem(
+    value: str,
+    label: str | None = None,
+    disabled: bool = False,
+    class_name: str = "",
+    cls: str = "",
+    indicator_cls: str = "",
+    **attrs: Any,
+) -> FT:
+    def _inject_signal(signal, group_name, default_value=None):
+        radio_id = f"radio_{str(uuid4())[:8]}"
+        filtered_attrs = {k: v for k, v in attrs.items() if k != "name"}
+
+        radio_input = HTMLInput(
+            ds_on_change(f"${signal} = '{value}'"),
+            type="radio",
+            id=radio_id,
+            value=value,
+            name=group_name,
+            disabled=disabled,
+            data_slot="radio-input",
+            cls="sr-only peer",
+            **filtered_attrs,
+        )
+
+        visual_radio = Div(
+            Div(
+                Div(cls="size-2 rounded-full bg-primary"),
+                ds_class(
+                    {
+                        "opacity-100": f"${signal} === '{value}'",
+                        "opacity-0": f"${signal} !== '{value}'",
+                    }
+                ),
+                cls=cn(
+                    "absolute inset-0 flex items-center justify-center",
+                    indicator_cls,
+                ),
+                data_slot="radio-indicator",
+            ),
+            cls=cn(
+                "relative aspect-square size-4 shrink-0 rounded-full border transition-all",
+                "border-input bg-background dark:bg-input/30",
+                "peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
+                class_name,
+                cls,
+            ),
+            data_slot="radio-visual",
+        )
+
+        container = Div(
+            radio_input,
+            visual_radio,
+            cls="relative inline-flex items-center",
+            data_slot="radio-container",
+        )
+
+        if not label:
+            return container
+
+        return Label(
+            container,
+            Span(
+                label,
+                cls="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-50",
+            ),
+            for_=radio_id,
+            cls="flex items-center gap-2 cursor-pointer",
+        )
+
+    _inject_signal._inject_signal = _inject_signal
+    return _inject_signal
+
+
+def RadioGroupWithLabel(
+    label: str,
+    options: list[dict[str, Any]],
+    value: str | None = None,
+    signal: str | None = None,
+    name: str | None = None,
+    helper_text: str | None = None,
+    error_text: str | None = None,
+    disabled: bool = False,
+    required: bool = False,
+    orientation: str = "vertical",
+    class_name: str = "",
+    cls: str = "",
+    **attrs: Any,
+) -> FT:
+    signal = signal or f"radio_{str(uuid4())[:8]}"
+    name = name or f"radio_group_{str(uuid4())[:8]}"
+    group_id = f"radiogroup_{str(uuid4())[:8]}"
+
+    radio_group_classes = cn(
+        "flex gap-2",
+        "flex-col" if orientation == "vertical" else "flex-row gap-6",
+    )
+
+    return Div(
+        label
+        and Label(
+            label,
+            required and Span(" *", cls="text-destructive") or None,
+            cls="text-sm font-medium mb-3 block",
+            for_=group_id,
+        )
+        or None,
+        RadioGroup(
+            *[
+                RadioGroupItem(
+                    value=option["value"],
+                    label=option.get("label"),
+                    signal=signal,
+                    name=name,
+                    disabled=disabled or option.get("disabled", False),
+                )
+                for option in options
+            ],
+            value=value,
+            signal=signal,
+            name=name,
+            disabled=disabled,
+            required=required,
+            cls=radio_group_classes,
+            id=group_id,
+            aria_invalid="true" if error_text else None,
+        ),
+        error_text and P(error_text, cls="text-sm text-destructive mt-1.5") or None,
+        helper_text
+        and not error_text
+        and P(helper_text, cls="text-sm text-muted-foreground mt-1.5")
+        or None,
+        cls=cn("space-y-1.5", class_name, cls),
+        **attrs,
+    )

--- a/test_sandbox/app.py
+++ b/test_sandbox/app.py
@@ -1,9 +1,8 @@
 #!/usr/bin/env python3
 # Import starhtml first, then override with our custom components
-from starhtml import *
-
 # Import all registry components at once (this will override starhtml components)
 from registry_loader import *
+from starhtml import *
 
 styles = Link(rel="stylesheet", href="/static/css/starui.css", type="text/css")
 
@@ -357,6 +356,80 @@ def index():
                     size="sm",
                 ),
                 cls="mb-8",
+            ),
+            # Radio Group examples
+            Div(
+                H2("Radio Groups", cls="text-2xl font-semibold mb-4"),
+                Div(
+                    RadioGroupWithLabel(
+                        "Select your plan",
+                        options=[
+                            {"value": "free", "label": "Free - $0/month"},
+                            {"value": "pro", "label": "Pro - $10/month"},
+                            {"value": "enterprise", "label": "Enterprise - Custom"},
+                        ],
+                        value="free",
+                        signal="plan",
+                        helper_text="Choose the plan that best fits your needs",
+                    ),
+                    RadioGroupWithLabel(
+                        label="Notification preferences",
+                        options=[
+                            {"value": "all", "label": "All notifications"},
+                            {"value": "important", "label": "Important only"},
+                            {"value": "none", "label": "No notifications"},
+                        ],
+                        signal="notifications_radio",
+                        orientation="horizontal",
+                        required=True,
+                    ),
+                    RadioGroupWithLabel(
+                        label="Size",
+                        options=[
+                            {"value": "sm", "label": "Small"},
+                            {"value": "md", "label": "Medium"},
+                            {"value": "lg", "label": "Large"},
+                            {"value": "xl", "label": "Extra Large", "disabled": True},
+                        ],
+                        signal="size_radio",
+                        required=True,
+                        error_text="Please select a size",
+                    ),
+                    Div(
+                        P("Simple radio group (fully auto-managed):", cls="text-sm font-medium mb-2"),
+                        RadioGroup(
+                            RadioGroupItem("small", "Small"),
+                            RadioGroupItem("medium", "Medium"),
+                            RadioGroupItem("large", "Large"),
+                            value="medium",
+                        ),
+                        cls="p-4 border rounded-lg",
+                    ),
+                    Div(
+                        P("Custom styled radio group (blue indicator):", cls="text-sm font-medium mb-2"),
+                        RadioGroup(
+                            RadioGroupItem(
+                                "option1",
+                                "Option 1",
+                                indicator_cls="[&>div]:bg-blue-600 dark:[&>div]:bg-blue-500"
+                            ),
+                            RadioGroupItem(
+                                "option2",
+                                "Option 2",
+                                indicator_cls="[&>div]:bg-blue-600 dark:[&>div]:bg-blue-500"
+                            ),
+                            RadioGroupItem(
+                                "option3",
+                                "Option 3",
+                                disabled=True,
+                                indicator_cls="[&>div]:bg-blue-600 dark:[&>div]:bg-blue-500"
+                            ),
+                            value="option2",
+                        ),
+                        cls="p-4 border rounded-lg",
+                    ),
+                    cls="space-y-6 mb-8",
+                ),
             ),
             # Checkbox examples
             Div(


### PR DESCRIPTION
## Summary
- ✅ Add RadioGroup and RadioGroupItem components with automatic signal injection pattern
- ✅ Implement RadioGroupWithLabel for complete form integration with validation
- ✅ Add proper disabled styling with opacity-50 to match checkbox behavior
- ✅ Fix semantic HTML across Badge, Card, and Sheet components
- ✅ Add comprehensive radio group examples to test app

## Key Features
- **Signal Injection Pattern**: Follows same architecture as Tabs component for automatic parent-child coordination
- **Proper Accessibility**: Uses semantic HTML elements, ARIA attributes, and proper radio button grouping
- **Disabled Styling**: Visual disabled state matches checkbox component behavior
- **Form Integration**: RadioGroupWithLabel provides complete form experience with labels, validation, and helper text

## Semantic HTML Improvements
- Badge: Use HTMLButton for clickable badges instead of Span with role="button"
- Card: Use H1-H6 elements for CardTitle, P for CardDescription  
- Sheet: Use H2 for SheetTitle, P for SheetDescription

## Test plan
- [x] Radio button selection works correctly across all groups
- [x] Disabled styling is visually apparent and matches checkbox behavior
- [x] Signal injection coordinates state between parent and children
- [x] All quality checks pass (ruff, pyright, pytest, build)
- [x] Test app demonstrates all component variations