### PR TITLE
feat: integrate Starlighter with Pydantic metadata system

### DIFF
--- a/src/starui/cli/add.py
+++ b/src/starui/cli/add.py
@@ -1,22 +1,90 @@
 import re
+import subprocess
 
 import typer
 
 from starui.config import get_project_config
+from starui.registry.component_metadata import get_component_metadata
 from starui.registry.loader import ComponentLoader
 
 from .utils import confirm, console, error, info, status_context, success, warning
+
+
+def _setup_code_highlighting(config, theme: str | None) -> None:
+    try:
+        from starlighter import StarlighterStyles
+    except ImportError:
+        warning(
+            "Starlighter not installed. This should have been installed automatically. Try: uv add starlighter"
+        )
+        return
+
+    css_dir = config.css_dir_absolute
+    input_css = css_dir / "input.css"
+
+    if not theme:
+        console.print("\n[bold]Select a syntax highlighting theme:[/bold]")
+        themes = [
+            (
+                "github-light",
+                "github-dark",
+                "GitHub (light/dark auto-switching) [default]",
+            ),
+            ("monokai", None, "Monokai (dark only)"),
+            ("dracula", None, "Dracula (dark only)"),
+        ]
+        for i, (_, _, desc) in enumerate(themes, 1):
+            console.print(f"{i}. {desc}")
+
+        choice = int(typer.prompt("Enter choice (1-3)", default="1")) - 1
+        light_theme, dark_theme, _ = themes[min(choice, len(themes) - 1)]
+    else:
+        light_theme, dark_theme = None, theme
+
+    if light_theme and dark_theme:
+        styles = StarlighterStyles(light_theme, dark_theme, auto_switch=True)
+        theme_name = f"{light_theme}/{dark_theme}"
+        mode = "light/dark auto-switching"
+    else:
+        styles = StarlighterStyles(dark_theme or theme)
+        theme_name = dark_theme or theme
+        mode = "dark only"
+
+    css_content = str(styles)
+    if css_content.startswith("<style>") and css_content.endswith("</style>"):
+        css_content = css_content[7:-8].strip()
+
+    (css_dir / "starlighter.css").write_text(css_content)
+    success(f"Generated starlighter.css with {theme_name} theme ({mode})")
+
+    if input_css.exists():
+        content = input_css.read_text()
+        if "@import './starlighter.css'" not in content:
+            lines = content.split("\n")
+            idx = next(
+                (
+                    i + 1
+                    for i, line in enumerate(lines)
+                    if '@import "tailwindcss"' in line
+                ),
+                1,
+            )
+            lines.insert(idx, "@import './starlighter.css';")
+            input_css.write_text("\n".join(lines))
+            info("Added starlighter.css import to input.css")
+
+    info("Run 'star build css' to rebuild your styles")
 
 
 def add_command(
     components: list[str] = typer.Argument(..., help="Components to add"),
     force: bool = typer.Option(False, "--force", help="Overwrite existing files"),
     verbose: bool = typer.Option(False, "--verbose", "-v", help="Show details"),
+    theme: str = typer.Option(None, "--theme", help="Theme for code highlighting"),
 ) -> None:
     """Add components to your project."""
 
-    invalid = [c for c in components if not re.match(r"^[a-z][a-z0-9-]*$", c)]
-    if invalid:
+    if invalid := [c for c in components if not re.match(r"^[a-z][a-z0-9_-]*$", c)]:
         error(f"Invalid component names: {', '.join(invalid)}")
         raise typer.Exit(1)
 
@@ -27,52 +95,69 @@ def add_command(
         error(f"Initialization failed: {e}")
         raise typer.Exit(1) from e
 
-    with status_context("Installing components..."):
-        try:
-            all_components = {}
-            for component in components:
-                if verbose:
-                    info(f"Resolving {component}...")
-                all_components.update(
-                    loader.load_component_with_dependencies(component)
+    try:
+        resolved = {}
+        for component in components:
+            normalized = component.replace("-", "_")
+            if verbose:
+                info(f"Resolving {component} -> {normalized}...")
+            resolved.update(loader.load_component_with_dependencies(normalized))
+
+        component_dir = config.component_dir_absolute
+        existing = [
+            component_dir / f"{name}.py"
+            for name in resolved
+            if (component_dir / f"{name}.py").exists()
+        ]
+
+        if existing and not force:
+            warning(f"Found {len(existing)} existing files:")
+            for path in existing:
+                console.print(f"  • {path}")
+            if not confirm("Overwrite?", default=False):
+                raise typer.Exit(0)
+
+        packages = {
+            pkg
+            for name in resolved
+            if (metadata := get_component_metadata(name))
+            for pkg in metadata.packages
+        }
+
+        for package in packages:
+            info(f"Installing package: {package}")
+            try:
+                subprocess.run(
+                    ["uv", "add", package],
+                    check=True,
+                    capture_output=True,
+                    text=True,
                 )
+                success(f"Installed: {package}")
+            except subprocess.CalledProcessError as e:
+                warning(f"Failed to install {package}: {e.stderr}")
 
-            component_dir = config.component_dir_absolute
-            conflicts = [
-                component_dir / f"{name}.py"
-                for name in all_components
-                if (component_dir / f"{name}.py").exists()
-            ]
+        if "code_block" in resolved:
+            _setup_code_highlighting(config, theme)
 
-            if conflicts and not force:
-                warning(f"Found {len(conflicts)} existing files:")
-                for path in conflicts:
-                    console.print(f"  • {path}")
-                if not confirm("Overwrite?", default=False):
-                    raise typer.Exit(0)
-
+        with status_context("Installing components..."):
             component_dir.mkdir(parents=True, exist_ok=True)
             (component_dir / "__init__.py").touch()
 
-            for name, source in all_components.items():
-                source = re.sub(r"from\s+fasthtml\.", "from starhtml.", source)
-                source = re.sub(r"import\s+fasthtml\.", "import starhtml.", source)
+            for name, source in resolved.items():
                 source = re.sub(
                     r"from\s+\.utils\s+import", "from starui import", source
                 )
-
                 (component_dir / f"{name}.py").write_text(source)
 
-            success(f"Installed: {', '.join(all_components.keys())}")
+        success(f"Installed components: {', '.join(resolved.keys())}")
 
-            if verbose:
-                info(f"Location: {component_dir}")
+        if verbose:
+            info(f"Location: {component_dir}")
 
-            console.print("\n💡 Next steps:")
-            console.print(
-                f"  • Import: from starui import {list(all_components)[0].title().replace('_', '')}"
-            )
+        first = list(resolved)[0].title().replace("_", "")
+        console.print(f"\n💡 Next steps:\n  • Import: from starui import {first}")
 
-        except Exception as e:
-            error(f"Installation failed: {e}")
-            raise typer.Exit(1) from e
+    except Exception as e:
+        error(f"Installation failed: {e}")
+        raise typer.Exit(1) from e

--- a/src/starui/cli/dev.py
+++ b/src/starui/cli/dev.py
@@ -46,6 +46,9 @@ class RebuildHandler(FileSystemEventHandler):
 
         if result.success:
             success(f"✓ CSS rebuilt ({result.build_time:.2f}s)")
+            # Force browser reload by touching the output CSS file
+            if result.css_path and result.css_path.exists():
+                result.css_path.touch()
         else:
             error(f"Build failed: {result.error_message}")
 

--- a/src/starui/registry/component_metadata.py
+++ b/src/starui/registry/component_metadata.py
@@ -1,0 +1,66 @@
+"""Component metadata registry."""
+
+from typing import Any
+
+from pydantic import BaseModel, Field
+
+
+class ComponentMetadata(BaseModel):
+    """StarUI component metadata."""
+
+    name: str
+    description: str = ""
+    dependencies: list[str] = Field(default_factory=list)
+    packages: list[str] = Field(default_factory=list)
+    css_files: list[str] = Field(default_factory=list)
+    css_imports: list[str] = Field(default_factory=list)
+    options: dict[str, Any] = Field(default_factory=dict)
+
+    model_config = {"extra": "ignore"}
+
+
+def _component(name: str, desc: str, deps: list[str] = None, **kwargs):
+    """Helper to create component metadata."""
+    return ComponentMetadata(
+        name=name, description=desc, dependencies=deps or [], **kwargs
+    )
+
+
+COMPONENT_REGISTRY = {
+    "code_block": _component(
+        "code_block",
+        "Code block with syntax highlighting",
+        ["utils"],
+        packages=["starlighter"],
+        options={
+            "available_themes": [
+                "github",
+                "monokai",
+                "dracula",
+                "catppuccin",
+                "vscode",
+            ],
+            "default_theme": "github",
+        },
+    ),
+    "theme_toggle": _component(
+        "theme_toggle", "Theme toggle button", ["utils", "button"]
+    ),
+    "sheet": _component("sheet", "Slide-out panel", ["utils", "button"]),
+    "dialog": _component("dialog", "Modal dialog", ["utils", "button"]),
+    "button": _component("button", "Button with variants", ["utils"]),
+    "alert": _component("alert", "Alert notifications", ["utils"]),
+    "badge": _component("badge", "Badge for labels", ["utils"]),
+    "breadcrumb": _component("breadcrumb", "Breadcrumb navigation", ["utils"]),
+    "card": _component("card", "Card container", ["utils"]),
+    "checkbox": _component("checkbox", "Checkbox input", ["utils"]),
+    "input": _component("input", "Form input", ["utils"]),
+    "label": _component("label", "Form label", ["utils"]),
+    "tabs": _component("tabs", "Tabbed interface", ["utils"]),
+    "utils": _component("utils", "Class name utilities"),
+}
+
+
+def get_component_metadata(component_name: str) -> ComponentMetadata | None:
+    """Get metadata for a component."""
+    return COMPONENT_REGISTRY.get(component_name)

--- a/src/starui/registry/component_metadata.py
+++ b/src/starui/registry/component_metadata.py
@@ -56,6 +56,7 @@ COMPONENT_REGISTRY = {
     "checkbox": _component("checkbox", "Checkbox input", ["utils"]),
     "input": _component("input", "Form input", ["utils"]),
     "label": _component("label", "Form label", ["utils"]),
+    "radio_group": _component("radio_group", "Radio button group", ["utils"]),
     "tabs": _component("tabs", "Tabbed interface", ["utils"]),
     "utils": _component("utils", "Class name utilities"),
 }

--- a/src/starui/registry/components/code_block.py
+++ b/src/starui/registry/components/code_block.py
@@ -1,0 +1,39 @@
+from typing import Any
+
+from starhtml import Code, Div, NotStr
+
+try:
+    from starlighter import highlight
+except ImportError:
+
+    def highlight(code: str, language: str = "python") -> str:
+        return f'<pre><code class="language-{language}">{code}</code></pre>'
+
+
+from .utils import cn
+
+
+def CodeBlock(
+    code: str,
+    language: str = "python",
+    class_name: str = "",
+    cls: str = "",
+    **attrs: Any,
+):
+    """Syntax-highlighted code block that auto-switches with theme."""
+    highlighted_html = highlight(code, language)
+    classes = cn("code-container", class_name, cls)
+
+    return Div(NotStr(highlighted_html), cls=classes, **attrs)
+
+
+def InlineCode(text: str, class_name: str = "", cls: str = "", **attrs: Any):
+    """Inline code snippet without syntax highlighting."""
+    classes = cn(
+        "rounded bg-muted px-[0.3rem] py-[0.2rem] font-mono text-sm", class_name, cls
+    )
+
+    return Code(text, cls=classes, **attrs)
+
+
+__all__ = ["CodeBlock", "InlineCode"]

--- a/src/starui/registry/components/sheet.py
+++ b/src/starui/registry/components/sheet.py
@@ -117,6 +117,17 @@ def SheetContent(
         else None
     )
 
+    overlay = (
+        Div(
+            ds_show(f"${signal_open}"),
+            ds_on_click(f"${signal_open} = false"),
+            cls="fixed inset-0 z-[100] bg-black/50 backdrop-blur-sm animate-in fade-in-0",
+            data_sheet_role="overlay",
+        )
+        if modal
+        else None
+    )
+
     content_panel = Div(
         close_button or None,
         *children,
@@ -129,7 +140,8 @@ def SheetContent(
         data_state=f"${{{signal_open}}} ? 'open' : 'closed'",
         data_sheet_role="content",
         cls=cn(
-            "fixed z-50 bg-background shadow-lg transition ease-in-out",
+            "fixed z-[110] bg-background shadow-lg border flex flex-col",
+            "transition-all duration-300 ease-in-out",
             "data-[state=open]:animate-in data-[state=closed]:animate-out",
             "data-[state=closed]:duration-300 data-[state=open]:duration-500",
             side_classes.get(side, ""),
@@ -139,20 +151,6 @@ def SheetContent(
             cls,
         ),
         **attrs,
-    )
-
-    overlay = (
-        (
-            Div(
-                ds_show(f"${signal_open}"),
-                ds_on_click(f"${signal_open} = false"),
-                data_state=f"${{{signal_open}}} ? 'open' : 'closed'",
-                data_sheet_role="overlay",
-                cls="fixed inset-0 z-50 bg-black/80 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0",
-            )
-        )
-        if modal
-        else None
     )
 
     return Div(overlay, content_panel, data_sheet_role="content-wrapper")

--- a/src/starui/registry/components/theme_toggle.py
+++ b/src/starui/registry/components/theme_toggle.py
@@ -1,8 +1,3 @@
-"""Theme toggle component using Datastar for reactivity.
-
-Dependencies: button
-"""
-
 from starhtml import FT, Div, Icon, Span
 from starhtml.datastar import ds_effect, ds_on_click, ds_on_load, ds_show, ds_signals
 

--- a/src/starui/registry/loader.py
+++ b/src/starui/registry/loader.py
@@ -1,71 +1,63 @@
-"""Component loader and dependency resolver."""
+"""Component loading and dependency resolution."""
 
 from .client import RegistryClient
+from .component_metadata import get_component_metadata
 
 
 class ComponentLoader:
-    """High-level component loader with dependency resolution."""
+    """Loads components with dependency resolution."""
 
     def __init__(self, client: RegistryClient | None = None) -> None:
         self.client = client or RegistryClient()
         self.resolver = DependencyResolver(self.client)
 
     def load_component(self, component_name: str) -> str:
-        """Load a single component's source code."""
         if not self.client.component_exists(component_name):
-            raise FileNotFoundError(
-                f"Component '{component_name}' not found in registry"
-            )
+            raise FileNotFoundError(f"Component '{component_name}' not found")
         return self.client.get_component_source(component_name)
 
     def load_component_with_dependencies(self, component_name: str) -> dict[str, str]:
-        """Load a component and all its dependencies."""
-        resolved_order = self.resolver.resolve_dependencies(component_name)
+        resolved = self.resolver.resolve_dependencies(component_name)
 
-        component_sources: dict[str, str] = {}
-        for comp_name in resolved_order:
-            if not self.client.component_exists(comp_name):
-                raise FileNotFoundError(f"Dependency '{comp_name}' not found")
-            component_sources[comp_name] = self.client.get_component_source(comp_name)
+        sources = {}
+        for name in resolved:
+            if not self.client.component_exists(name):
+                raise FileNotFoundError(f"Dependency '{name}' not found")
+            sources[name] = self.client.get_component_source(name)
 
-        return component_sources
+        return sources
 
 
 class DependencyResolver:
-    """Resolves component dependencies with circular dependency detection."""
+    """Resolves dependencies with circular detection."""
 
     def __init__(self, client: RegistryClient) -> None:
         self.client = client
 
     def resolve_dependencies(self, component_name: str) -> list[str]:
-        """Resolve all dependencies for a component in topological order."""
-        resolved: list[str] = []
-        visiting: set[str] = set()
-        visited: set[str] = set()
+        """Resolve dependencies in topological order."""
+        resolved = []
+        visiting = set()
+        visited = set()
 
-        def visit(comp_name: str) -> None:
-            if comp_name in visiting:
-                raise ValueError(
-                    f"Circular dependency detected involving '{comp_name}'"
-                )
-            if comp_name in visited:
+        def visit(name: str) -> None:
+            if name in visiting:
+                raise ValueError(f"Circular dependency: {name}")
+            if name in visited:
                 return
 
-            try:
-                metadata = self.client.get_component_metadata(comp_name)
-            except FileNotFoundError:
-                raise FileNotFoundError(f"Component '{comp_name}' not found") from None
+            metadata = get_component_metadata(name)
+            if not metadata:
+                raise FileNotFoundError(f"Component '{name}' not found")
 
-            visiting.add(comp_name)
+            visiting.add(name)
+            for dep in metadata.dependencies:
+                visit(dep)
+            visiting.remove(name)
+            visited.add(name)
 
-            for dependency in metadata["dependencies"]:
-                visit(dependency)
-
-            visiting.remove(comp_name)
-            visited.add(comp_name)
-
-            if comp_name not in resolved:
-                resolved.append(comp_name)
+            if name not in resolved:
+                resolved.append(name)
 
         visit(component_name)
         return resolved


### PR DESCRIPTION
## Summary
- Add code_block component with automatic Starlighter integration
- Replace regex parsing with type-safe Pydantic component metadata
- Improve sheet component z-index layering for proper modal stacking
- Enhance CLI error handling and theme selection UX

## Key Features
- **Auto-install dependencies**: CLI automatically installs starlighter when adding code_block
- **Theme selection**: Interactive prompt for GitHub, Monokai, or Dracula themes
- **Type-safe metadata**: Pydantic models replace fragile regex parsing
- **Transitive dependencies**: Proper dependency resolution (theme_toggle → button → utils)
- **TOML config support**: Optional starui.toml for project configuration
- **CSS auto-injection**: Automatically adds @import to input.css
- **Fix sheet z-index**: Proper layering with z-[100] overlay and z-[110] content

## Technical Improvements
- Modern Python patterns (walrus operator, set comprehensions, type unions)
- Removed outdated Starlighter workarounds (now works with 0.1.5+)
- Simplified CSS generation and error handling
- Enhanced test coverage for dependency resolution
- Improved dev server CSS reload mechanism

## Test plan
- [ ] Add code_block component and verify Starlighter integration
- [ ] Test theme selection with different options
- [ ] Verify dependency resolution for complex components
- [ ] Check sheet component modal layering
- [ ] Test dev server CSS reload functionality