### PR TITLE
feat: CSS hot reload with separate process architecture

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,11 +20,11 @@ classifiers = [
 # Core dependencies
 dependencies = [
     "typer>=0.9.0,<1.0.0",
-    "watchdog>=3.0.0,<4.0.0",
     "requests>=2.31.0,<3.0.0",
     "pydantic>=2.5.0,<3.0.0",
     "rich>=13.7.0,<14.0.0",
     "starhtml==0.1.13",
+    "websockets>=12.0.0,<13.0.0",
 ]
 
 # Optional dependencies for development - using dependency-groups below for UV compatibility

--- a/src/starui/cli/dev.py
+++ b/src/starui/cli/dev.py
@@ -1,180 +1,188 @@
-import signal
-import subprocess
-import sys
+"""Development server with CSS hot reload."""
+
+import asyncio
+import tempfile
 import time
 from pathlib import Path
-from typing import Any, cast
 
 import typer
 from rich.panel import Panel
 from rich.table import Table
-from watchdog.events import FileSystemEvent, FileSystemEventHandler
-from watchdog.observers import Observer
 
 from ..config import detect_project_config
-from ..css.builder import BuildMode, CSSBuilder
-from .utils import console, error, info, success
-
-
-class RebuildHandler(FileSystemEventHandler):
-    """Handler for file system events that triggers CSS rebuilds."""
-
-    def __init__(self, builder: CSSBuilder, verbose: bool = False):
-        self.builder = builder
-        self.verbose = verbose
-        self.last_build = time.time()
-
-    def on_modified(self, event: FileSystemEvent) -> None:
-        if event.is_directory:
-            return
-        path = Path(cast(str, event.src_path))
-        if path.suffix in {".py", ".html", ".css", ".js"}:
-            self._rebuild(path)
-
-    def _rebuild(self, changed_path: Path) -> None:
-        now = time.time()
-        if now - self.last_build < 0.5:  # Debounce
-            return
-
-        if self.verbose:
-            info(f"Changed: {changed_path}")
-
-        with console.status("[bold yellow]Rebuilding CSS..."):
-            result = self.builder.build(
-                BuildMode.DEVELOPMENT, watch=False, scan_content=True
-            )
-
-        if result.success:
-            success(f"✓ CSS rebuilt ({result.build_time:.2f}s)")
-            # Force browser reload by touching the output CSS file
-            if result.css_path and result.css_path.exists():
-                result.css_path.touch()
-        else:
-            error(f"Build failed: {result.error_message}")
-
-        self.last_build = now
+from ..css.binary import TailwindBinaryManager
+from ..dev import CSSHotReloadServer
+from ..dev.process_manager import ProcessManager
+from ..templates.css_input import generate_css_input
+from .utils import console, error, success
 
 
 def dev_command(
     app_file: str | None = typer.Argument(None, help="StarHTML app file to run"),
     port: int = typer.Option(5000, "--port", "-p", help="Port for app server"),
-    watch: bool = typer.Option(True, "--watch/--no-watch", help="Watch for changes"),
+    css_hot_reload: bool = typer.Option(
+        True, "--css-hot/--no-css-hot", help="Enable CSS hot reload"
+    ),
     verbose: bool = typer.Option(False, "--verbose", "-v", help="Show details"),
 ) -> None:
-    """Start development server with CSS watching."""
+    """Start development server with CSS hot reload."""
+
+    if not app_file:
+        error("App file is required")
+        raise typer.Exit(1)
+
+    app_path = Path(app_file)
+    if not app_path.exists():
+        error(f"App file not found: {app_file}")
+        raise typer.Exit(1)
+
+    config = detect_project_config()
+    manager = ProcessManager()
+    input_css_path = None
 
     try:
-        config = detect_project_config()
-        builder = CSSBuilder(config)
+        input_css_path = _prepare_css_input(config)
+        websocket_server = _start_css_hot_reload(css_hot_reload, manager, verbose)
+        _start_tailwind_watcher(manager, input_css_path, config, websocket_server)
+        _wait_for_css_build(config)
+        _start_app_server(manager, app_path, port, css_hot_reload)
+        _display_info(config, port, css_hot_reload, app_file)
 
-        # Initial build
-        with console.status("[bold green]Building CSS..."):
-            result = builder.build(
-                BuildMode.DEVELOPMENT, watch=False, scan_content=True
-            )
-            if not result.success:
-                error(f"Initial build failed: {result.error_message}")
-                raise typer.Exit(1)
-
-        success("✓ Initial CSS build completed")
-        if verbose:
-            if result.build_time:
-                info(f"Build time: {result.build_time:.2f}s")
-            if result.css_size_bytes:
-                info(f"CSS size: {result.css_size_bytes / 1024:.1f} KB")
-            if result.classes_found:
-                info(f"CSS classes found: {result.classes_found}")
-
-        # Start app server if provided
-        app_process: subprocess.Popen[str] | None = None
-        if app_file:
-            app_path = Path(app_file)
-            if not app_path.exists():
-                error(f"App file not found: {app_file}")
-                raise typer.Exit(1)
-
-            cmd = [
-                sys.executable,
-                "-m",
-                "uvicorn",
-                f"{app_path.stem}:app",
-                "--reload",
-                "--port",
-                str(port),
-                "--host",
-                "localhost",
-            ]
-
-            if config.css_output_absolute.exists():
-                try:
-                    css_path = config.css_output_absolute.relative_to(
-                        config.project_root
-                    )
-                    cmd.extend(["--reload-include", str(css_path)])
-                except ValueError:
-                    pass
-
-            app_process = subprocess.Popen(cmd, text=True)
-            success(f"✓ App server started at http://localhost:{port}")
-
-        if watch:
-            success("✓ File watcher started")
-
-        # Display server info
-        table = Table(title="Star Development Server", show_header=False)
-        table.add_column(style="cyan")
-        table.add_column(style="green")
-        table.add_row("✓ Development server started", "")
-        table.add_row("Project", str(config.project_root.name))
-        table.add_row("CSS Output", str(config.css_output))
-        table.add_row("Framework", "StarHTML")
-        table.add_row("File Watching", "Enabled" if watch else "Disabled")
-        if app_file:
-            table.add_row("App Server", f"http://localhost:{port}")
-            table.add_row("App File", app_file)
-
-        console.print(Panel(table, border_style="green"))
-        console.print("\nKeyboard shortcuts:")
-        console.print("  Ctrl+C  Stop the server\n")
-
-        if app_file:
-            console.print("App server logs will appear below...\n")
-
-        console.print("Press Ctrl+C to stop the development server")
-
-        # Setup file watching
-        observer = None
-        if watch:
-            observer = Observer()
-            handler = RebuildHandler(builder, verbose)
-            observer.schedule(handler, str(config.project_root), recursive=True)  # type: ignore
-            observer.start()
-
-        # Handle shutdown
-        def shutdown_handler(_sig: Any, _frame: Any) -> None:
-            console.print("\n[yellow]Shutting down...[/yellow]")
-            if observer:
-                observer.stop()
-                observer.join()
-            if app_process:
-                app_process.terminate()
-            sys.exit(0)
-
-        signal.signal(signal.SIGINT, shutdown_handler)
-        signal.signal(signal.SIGTERM, shutdown_handler)
-
+        console.print("Press Ctrl+C to stop\n")
         try:
-            if app_process:
-                app_process.wait()
-            elif observer:
-                observer.join()
-            else:
-                # Just wait if no watching and no app
-                while True:
-                    time.sleep(1)
+            manager.wait_for_any_exit()
         except KeyboardInterrupt:
-            shutdown_handler(None, None)
+            console.print("\n[yellow]Shutting down...[/yellow]")
 
     except Exception as e:
         error(f"Dev server error: {e}")
         raise typer.Exit(1) from e
+    finally:
+        manager.stop_all()
+        _cleanup_temp_files(input_css_path, config, app_path, verbose)
+
+
+def _prepare_css_input(config) -> Path:
+    """Get or create CSS input file for Tailwind."""
+    project_input = config.project_root / "static" / "css" / "input.css"
+
+    if project_input.exists():
+        return project_input
+
+    config.css_output_absolute.parent.mkdir(parents=True, exist_ok=True)
+
+    with tempfile.NamedTemporaryFile(
+        mode="w",
+        suffix=".css",
+        dir=config.css_output_absolute.parent,
+        delete=False,
+    ) as f:
+        f.write(generate_css_input(config))
+        return Path(f.name)
+
+
+def _start_css_hot_reload(
+    enabled: bool, manager: ProcessManager, verbose: bool
+) -> CSSHotReloadServer | None:
+    """Start CSS hot reload WebSocket server if enabled."""
+    if not enabled:
+        return None
+
+    try:
+        loop = asyncio.new_event_loop()
+        websocket_server = CSSHotReloadServer(port=5001)
+        manager.start_websocket_server(websocket_server, loop)
+        success("✓ CSS hot reload enabled")
+        return websocket_server
+    except Exception as e:
+        error(f"Failed to start CSS hot reload: {e}")
+        return None
+
+
+def _start_tailwind_watcher(
+    manager: ProcessManager, input_css: Path, config, websocket_server
+):
+    """Start Tailwind CSS watcher process."""
+    binary_manager = TailwindBinaryManager("latest")
+
+    def notify_css_update(css_path: Path):
+        if websocket_server:
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+            try:
+                loop.run_until_complete(websocket_server.notify_css_update(css_path, 0))
+            except Exception:
+                pass
+            finally:
+                loop.close()
+
+    manager.start_tailwind_watcher(
+        tailwind_binary=Path(binary_manager.get_binary()),
+        input_css=input_css,
+        output_css=config.css_output_absolute,
+        project_root=config.project_root,
+        on_rebuild=notify_css_update if websocket_server else None,
+    )
+
+
+def _wait_for_css_build(config):
+    """Wait for initial CSS build to complete."""
+    if config.css_output_absolute.exists():
+        success("✓ CSS ready")
+        return
+
+    console.print("[yellow]Building CSS...[/yellow]")
+    for _ in range(20):
+        if config.css_output_absolute.exists():
+            success("✓ CSS built")
+            return
+        time.sleep(0.5)
+
+    error("CSS build timed out")
+    raise typer.Exit(1)
+
+
+def _start_app_server(
+    manager: ProcessManager, app_path: Path, port: int, css_hot_reload: bool = True
+):
+    """Start uvicorn app server."""
+    manager.start_uvicorn(
+        app_file=app_path,
+        port=port,
+        watch_patterns=["*.py", "*.html"],
+        enable_css_hot_reload=css_hot_reload,
+    )
+    success(f"✓ Server running at http://localhost:{port}")
+
+
+def _display_info(config, port: int, css_hot_reload: bool, app_file: str):
+    """Display development server status."""
+    table = Table(title="StarUI Development Server", show_header=False)
+    table.add_column(style="cyan")
+    table.add_column(style="green")
+
+    table.add_row("App", f"http://localhost:{port}")
+    table.add_row("File", app_file)
+    table.add_row("CSS", str(config.css_output))
+    table.add_row("Hot Reload", "✓" if css_hot_reload else "✗")
+
+    console.print(Panel(table, border_style="green"))
+
+
+def _cleanup_temp_files(
+    input_css_path: Path | None, config, app_path: Path, verbose: bool
+):
+    """Clean up temporary files."""
+    if input_css_path and input_css_path.name.startswith("tmp"):
+        input_css_path.unlink(missing_ok=True)
+
+    # Clean up dev wrapper file
+    wrapper_file = app_path.parent / f"{app_path.stem}_dev.py"
+    if wrapper_file.exists():
+        wrapper_file.unlink()
+
+    try:
+        for temp_file in config.css_output_absolute.parent.glob("tmp*.css"):
+            temp_file.unlink()
+    except Exception:
+        pass

--- a/src/starui/cli/dev.py
+++ b/src/starui/cli/dev.py
@@ -18,8 +18,7 @@ from ..templates.css_input import generate_css_input
 from .utils import console, error, success
 
 
-def check_port_available(port: int) -> bool:
-    """Check if a port is available."""
+def port_available(port: int) -> bool:
     try:
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
             s.bind(("localhost", port))
@@ -28,14 +27,119 @@ def check_port_available(port: int) -> bool:
         return False
 
 
-def find_available_port(start_port: int = 5000, max_tries: int = 100) -> int:
-    """Find an available port starting from start_port."""
-    for port in range(start_port, start_port + max_tries):
-        if check_port_available(port):
+def find_port(start: int = 5000, max_tries: int = 100) -> int:
+    for port in range(start, start + max_tries):
+        if port_available(port):
             return port
-    raise RuntimeError(
-        f"No available ports in range {start_port}-{start_port + max_tries}"
+    raise RuntimeError(f"No ports available in {start}-{start + max_tries}")
+
+
+def resolve_port(requested: int, strict: bool) -> int:
+    if port_available(requested):
+        return requested
+
+    if strict:
+        error(f"Port {requested} is already in use")
+        raise typer.Exit(1)
+
+    console.print(f"[yellow]Port {requested} in use, finding available...[/yellow]")
+    available = find_port(requested + 1)
+    success(f"✓ Using port {available}")
+    return available
+
+
+def prepare_css_input(config) -> Path:
+    project_input = config.project_root / "static" / "css" / "input.css"
+    if project_input.exists():
+        return project_input
+
+    css_dir = config.css_output_absolute.parent
+    css_dir.mkdir(parents=True, exist_ok=True)
+
+    with tempfile.NamedTemporaryFile(
+        mode="w", suffix=".css", dir=css_dir, delete=False
+    ) as f:
+        f.write(generate_css_input(config))
+        return Path(f.name)
+
+
+def start_css_websocket(
+    port: int, manager: ProcessManager
+) -> CSSHotReloadServer | None:
+    try:
+        loop = asyncio.new_event_loop()
+        server = CSSHotReloadServer(port=port)
+        manager.start_websocket_server(server, loop)
+        success(f"✓ CSS hot reload on port {port}")
+        return server
+    except Exception as e:
+        error(f"CSS hot reload failed: {e}")
+        return None
+
+
+def start_tailwind(manager: ProcessManager, input_css: Path, config, ws_server):
+    binary = TailwindBinaryManager("latest").get_binary()
+
+    callback = None
+    if ws_server:
+
+        def callback(css_path: Path):
+            loop = asyncio.new_event_loop()
+            asyncio.set_event_loop(loop)
+            try:
+                loop.run_until_complete(ws_server.notify_css_update(css_path, 0))
+            except Exception:
+                pass
+            finally:
+                loop.close()
+
+    manager.start_tailwind_watcher(
+        tailwind_binary=Path(binary),
+        input_css=input_css,
+        output_css=config.css_output_absolute,
+        project_root=config.project_root,
+        on_rebuild=callback,
     )
+
+
+def wait_for_css(config, timeout: int = 10):
+    if config.css_output_absolute.exists():
+        success("✓ CSS ready")
+        return
+
+    console.print("[yellow]Building CSS...[/yellow]")
+    for _ in range(timeout * 2):  # Check every 0.5s
+        if config.css_output_absolute.exists():
+            success("✓ CSS built")
+            return
+        time.sleep(0.5)
+
+    error("CSS build timed out")
+    raise typer.Exit(1)
+
+
+def cleanup_files(input_css: Path | None, config, app_path: Path):
+    if input_css and input_css.name.startswith("tmp"):
+        input_css.unlink(missing_ok=True)
+
+    for wrapper in app_path.parent.glob(f"{app_path.stem}_dev_*.py"):
+        wrapper.unlink(missing_ok=True)
+
+    for temp in config.css_output_absolute.parent.glob("tmp*.css"):
+        temp.unlink(missing_ok=True)
+
+
+def show_status(config, port: int, ws_port: int, css_hot: bool, app_file: str):
+    table = Table(title="StarUI Development Server", show_header=False)
+    table.add_column(style="cyan")
+    table.add_column(style="green")
+
+    table.add_row("App", f"http://localhost:{port}")
+    table.add_row("File", app_file)
+    table.add_row("CSS", str(config.css_output))
+    table.add_row("Hot Reload", f"✓ (WebSocket on port {ws_port})" if css_hot else "✗")
+
+    console.print(Panel(table, border_style="green"))
 
 
 def dev_command(
@@ -54,7 +158,6 @@ def dev_command(
     By default, if the requested port is in use, automatically finds the next
     available port. Use --strict to disable this behavior.
     """
-
     if not app_file:
         error("App file is required")
         raise typer.Exit(1)
@@ -66,35 +169,29 @@ def dev_command(
 
     config = detect_project_config()
     manager = ProcessManager()
-    input_css_path = None
+    input_css = None
 
-    # Handle port availability
-    if check_port_available(port):
-        actual_port = port
-    elif strict:
-        error(f"Port {port} is already in use")
-        raise typer.Exit(1)
-    else:
-        console.print(
-            f"[yellow]Port {port} is in use, finding available port...[/yellow]"
-        )
-        actual_port = find_available_port(port + 1)
-        success(f"✓ Using port {actual_port} instead")
-
-    # Always auto-discover CSS WebSocket port
-    css_ws_port = find_available_port(actual_port + 1)  # Try next port after app port
+    app_port = resolve_port(port, strict)
+    ws_port = find_port(app_port + 1)
 
     try:
-        input_css_path = _prepare_css_input(config)
-        websocket_server = _start_css_hot_reload(
-            css_hot_reload, css_ws_port, manager, verbose
-        )
-        _start_tailwind_watcher(manager, input_css_path, config, websocket_server)
-        _wait_for_css_build(config)
-        _start_app_server(manager, app_path, actual_port, css_ws_port, css_hot_reload)
-        _display_info(config, actual_port, css_ws_port, css_hot_reload, app_file)
+        input_css = prepare_css_input(config)
+        ws_server = start_css_websocket(ws_port, manager) if css_hot_reload else None
+        start_tailwind(manager, input_css, config, ws_server)
+        wait_for_css(config)
 
+        manager.start_uvicorn(
+            app_file=app_path,
+            port=app_port,
+            watch_patterns=["*.py", "*.html"],
+            enable_css_hot_reload=css_hot_reload,
+            css_ws_port=ws_port,
+        )
+        success(f"✓ Server running at http://localhost:{app_port}")
+
+        show_status(config, app_port, ws_port, css_hot_reload, app_file)
         console.print("Press Ctrl+C to stop\n")
+
         try:
             manager.wait_for_any_exit()
         except KeyboardInterrupt:
@@ -105,139 +202,4 @@ def dev_command(
         raise typer.Exit(1) from e
     finally:
         manager.stop_all()
-        _cleanup_temp_files(input_css_path, config, app_path, verbose)
-
-
-def _prepare_css_input(config) -> Path:
-    """Get or create CSS input file for Tailwind."""
-    project_input = config.project_root / "static" / "css" / "input.css"
-
-    if project_input.exists():
-        return project_input
-
-    config.css_output_absolute.parent.mkdir(parents=True, exist_ok=True)
-
-    with tempfile.NamedTemporaryFile(
-        mode="w",
-        suffix=".css",
-        dir=config.css_output_absolute.parent,
-        delete=False,
-    ) as f:
-        f.write(generate_css_input(config))
-        return Path(f.name)
-
-
-def _start_css_hot_reload(
-    enabled: bool, port: int, manager: ProcessManager, verbose: bool
-) -> CSSHotReloadServer | None:
-    """Start CSS hot reload WebSocket server if enabled."""
-    if not enabled:
-        return None
-
-    try:
-        loop = asyncio.new_event_loop()
-        websocket_server = CSSHotReloadServer(port=port)
-        manager.start_websocket_server(websocket_server, loop)
-        success(f"✓ CSS hot reload enabled on port {port}")
-        return websocket_server
-    except Exception as e:
-        error(f"Failed to start CSS hot reload: {e}")
-        return None
-
-
-def _start_tailwind_watcher(
-    manager: ProcessManager, input_css: Path, config, websocket_server
-):
-    """Start Tailwind CSS watcher process."""
-    binary_manager = TailwindBinaryManager("latest")
-
-    def notify_css_update(css_path: Path):
-        if websocket_server:
-            loop = asyncio.new_event_loop()
-            asyncio.set_event_loop(loop)
-            try:
-                loop.run_until_complete(websocket_server.notify_css_update(css_path, 0))
-            except Exception:
-                pass
-            finally:
-                loop.close()
-
-    manager.start_tailwind_watcher(
-        tailwind_binary=Path(binary_manager.get_binary()),
-        input_css=input_css,
-        output_css=config.css_output_absolute,
-        project_root=config.project_root,
-        on_rebuild=notify_css_update if websocket_server else None,
-    )
-
-
-def _wait_for_css_build(config):
-    """Wait for initial CSS build to complete."""
-    if config.css_output_absolute.exists():
-        success("✓ CSS ready")
-        return
-
-    console.print("[yellow]Building CSS...[/yellow]")
-    for _ in range(20):
-        if config.css_output_absolute.exists():
-            success("✓ CSS built")
-            return
-        time.sleep(0.5)
-
-    error("CSS build timed out")
-    raise typer.Exit(1)
-
-
-def _start_app_server(
-    manager: ProcessManager,
-    app_path: Path,
-    port: int,
-    css_ws_port: int,
-    css_hot_reload: bool = True,
-):
-    """Start uvicorn app server."""
-    manager.start_uvicorn(
-        app_file=app_path,
-        port=port,
-        watch_patterns=["*.py", "*.html"],
-        enable_css_hot_reload=css_hot_reload,
-        css_ws_port=css_ws_port,
-    )
-    success(f"✓ Server running at http://localhost:{port}")
-
-
-def _display_info(
-    config, port: int, css_ws_port: int, css_hot_reload: bool, app_file: str
-):
-    """Display development server status."""
-    table = Table(title="StarUI Development Server", show_header=False)
-    table.add_column(style="cyan")
-    table.add_column(style="green")
-
-    table.add_row("App", f"http://localhost:{port}")
-    table.add_row("File", app_file)
-    table.add_row("CSS", str(config.css_output))
-    if css_hot_reload:
-        table.add_row("Hot Reload", f"✓ (WebSocket on port {css_ws_port})")
-    else:
-        table.add_row("Hot Reload", "✗")
-
-    console.print(Panel(table, border_style="green"))
-
-
-def _cleanup_temp_files(
-    input_css_path: Path | None, config, app_path: Path, verbose: bool
-):
-    """Clean up temporary files."""
-    if input_css_path and input_css_path.name.startswith("tmp"):
-        input_css_path.unlink(missing_ok=True)
-
-    # Clean up all dev wrapper files
-    for wrapper_file in app_path.parent.glob(f"{app_path.stem}_dev_*.py"):
-        wrapper_file.unlink(missing_ok=True)
-
-    try:
-        for temp_file in config.css_output_absolute.parent.glob("tmp*.css"):
-            temp_file.unlink()
-    except Exception:
-        pass
+        cleanup_files(input_css, config, app_path)

--- a/src/starui/dev/__init__.py
+++ b/src/starui/dev/__init__.py
@@ -1,0 +1,5 @@
+"""StarUI development tools."""
+
+from .websocket_server import CSSHotReloadServer
+
+__all__ = ["CSSHotReloadServer"]

--- a/src/starui/dev/middleware.py
+++ b/src/starui/dev/middleware.py
@@ -1,0 +1,115 @@
+"""ASGI middleware for CSS hot reload injection."""
+
+from collections.abc import Awaitable, Callable
+from typing import Any
+
+
+class CSSHotReloadMiddleware:
+    """Injects CSS hot reload script into HTML responses."""
+
+    SCRIPT = b"""<script>
+(()=>{
+if(!['localhost','127.0.0.1'].includes(location.hostname))return;
+const ws=new WebSocket('ws://localhost:5001/css-hot-reload');
+ws.onmessage=e=>{
+const m=JSON.parse(e.data);
+if(m.type==='css-update')[...document.querySelectorAll('link[href*="starui.css"]')].forEach(l=>{
+const n=l.cloneNode();n.href=l.href.split('?')[0]+'?t='+Date.now();
+n.onload=()=>l.remove();l.after(n);
+console.log(`[CSS] Updated in ${(m.buildTime||0).toFixed(2)}s`);
+})};
+ws.onopen=()=>console.log('[CSS] Hot reload connected');
+ws.onclose=()=>setTimeout(()=>location.reload(),1000);
+})()
+</script>"""
+
+    def __init__(
+        self, app: Callable[[dict[str, Any], Callable, Callable], Awaitable[None]]
+    ):
+        self.app = app
+
+    async def __call__(
+        self,
+        scope: dict[str, Any],
+        receive: Callable[[], Awaitable[dict[str, Any]]],
+        send: Callable[[dict[str, Any]], Awaitable[None]],
+    ) -> None:
+        if scope["type"] != "http":
+            await self.app(scope, receive, send)
+            return
+
+        # Buffer response to potentially modify HTML
+        response_started = False
+        response_body = bytearray()
+        headers: list[tuple[bytes, bytes]] = []
+        status_code = 200
+
+        async def send_wrapper(message: dict[str, Any]) -> None:
+            nonlocal response_started, response_body, headers, status_code
+
+            if message["type"] == "http.response.start":
+                response_started = True
+                headers = message.get("headers", [])
+                status_code = message.get("status", 200)
+                return  # Don't send yet, buffer it
+
+            elif message["type"] == "http.response.body":
+                body = message.get("body", b"")
+                if body:
+                    response_body.extend(body)
+
+                # If this is the last chunk
+                if not message.get("more_body", False):
+                    # Check if this is an HTML response
+                    content_type = None
+                    for name, value in headers:
+                        if name.lower() == b"content-type":
+                            content_type = value.decode(
+                                "utf-8", errors="ignore"
+                            ).lower()
+                            break
+
+                    if content_type and "text/html" in content_type:
+                        if b"</head>" in response_body:
+                            response_body = response_body.replace(
+                                b"</head>", self.SCRIPT + b"</head>"
+                            )
+                        elif b"</body>" in response_body:
+                            response_body = response_body.replace(
+                                b"</body>", self.SCRIPT + b"</body>"
+                            )
+                        else:
+                            response_body += self.SCRIPT
+
+                        # Update content-length if present
+                        new_headers = []
+                        for name, value in headers:
+                            if name.lower() == b"content-length":
+                                new_headers.append(
+                                    (name, str(len(response_body)).encode())
+                                )
+                            else:
+                                new_headers.append((name, value))
+                        headers = new_headers
+
+                    # Send the buffered response
+                    await send(
+                        {
+                            "type": "http.response.start",
+                            "status": status_code,
+                            "headers": headers,
+                        }
+                    )
+                    await send(
+                        {
+                            "type": "http.response.body",
+                            "body": bytes(response_body),
+                            "more_body": False,
+                        }
+                    )
+                    return
+
+            # For other message types, pass through
+            await send(message)
+
+        await self.app(scope, receive, send_wrapper)

--- a/src/starui/dev/process_manager.py
+++ b/src/starui/dev/process_manager.py
@@ -1,0 +1,219 @@
+"""Development process coordination."""
+
+import asyncio
+import os
+import subprocess
+import sys
+import threading
+import time
+from pathlib import Path
+
+from rich.console import Console
+
+console = Console()
+
+
+class ProcessManager:
+    def __init__(self):
+        self.processes = {}
+        self.threads = {}
+        self.shutdown_event = threading.Event()
+
+    def start_process(
+        self, name: str, cmd: list[str], cwd: Path = None, env: dict = None
+    ) -> subprocess.Popen:
+        if name in self.processes:
+            console.print(f"[yellow]{name} already running[/yellow]")
+            return self.processes[name]
+
+        console.print(f"[green]Starting {name}...[/green]")
+        process = subprocess.Popen(
+            cmd,
+            cwd=str(cwd) if cwd else None,
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            universal_newlines=True,
+            bufsize=1,
+        )
+        self.processes[name] = process
+
+        thread = threading.Thread(
+            target=self._monitor_output, args=(name, process), daemon=True
+        )
+        thread.start()
+        self.threads[f"{name}_monitor"] = thread
+        return process
+
+    def _monitor_output(self, name: str, process: subprocess.Popen):
+        try:
+            while process.poll() is None and not self.shutdown_event.is_set():
+                if line := process.stdout.readline():
+                    if clean := line.strip():
+                        console.print(f"[dim cyan][{name}][/dim cyan] {clean}")
+                else:
+                    time.sleep(0.1)
+        except Exception as e:
+            console.print(f"[red]Error monitoring {name}: {e}[/red]")
+
+    def start_uvicorn(
+        self,
+        app_file: Path,
+        port: int,
+        watch_patterns: list[str] = None,
+        enable_css_hot_reload: bool = True,
+    ) -> subprocess.Popen:
+        if enable_css_hot_reload:
+            wrapper_file = app_file.parent / f"{app_file.stem}_dev.py"
+            if not wrapper_file.exists():
+                wrapper_file.write_text(f"""from {app_file.stem} import app as original_app
+from starui.dev.middleware import CSSHotReloadMiddleware
+app = CSSHotReloadMiddleware(original_app)""")
+            app_module = f"{wrapper_file.stem}:app"
+        else:
+            app_module = f"{app_file.stem}:app"
+
+        cmd = [
+            sys.executable,
+            "-m",
+            "uvicorn",
+            app_module,
+            "--reload",
+            "--port",
+            str(port),
+            "--host",
+            "localhost",
+            "--reload-delay",
+            "0.1",
+        ]
+
+        patterns = watch_patterns or ["*.py", "*.html"]
+        for p in patterns:
+            cmd.extend(["--reload-include", p])
+
+        for exclude in [
+            "*.css",
+            "static/**",
+            "**/tmp*",
+            "**/__pycache__/**",
+            "*_dev.py",
+        ]:
+            cmd.extend(["--reload-exclude", exclude])
+
+        env = os.environ.copy()
+        return self.start_process("uvicorn", cmd, app_file.parent, env=env)
+
+    def start_tailwind_watcher(
+        self,
+        tailwind_binary: Path,
+        input_css: Path,
+        output_css: Path,
+        project_root: Path,
+        on_rebuild: callable = None,
+    ) -> subprocess.Popen:
+        cmd = [
+            str(tailwind_binary),
+            "--input",
+            str(input_css),
+            "--output",
+            str(output_css),
+            "--watch=always",
+            "--cwd",
+            str(project_root),
+        ]
+        process = self.start_process("tailwind", cmd, project_root)
+
+        if on_rebuild:
+
+            def monitor():
+                last_mtime = output_css.stat().st_mtime if output_css.exists() else 0
+                if last_mtime:
+                    on_rebuild(output_css)
+
+                while not self.shutdown_event.is_set():
+                    try:
+                        if (
+                            output_css.exists()
+                            and (mtime := output_css.stat().st_mtime) > last_mtime
+                        ):
+                            last_mtime = mtime
+                            on_rebuild(output_css)
+                    except Exception:
+                        pass
+                    time.sleep(0.5)
+
+            thread = threading.Thread(target=monitor, daemon=True)
+            thread.start()
+            self.threads["tailwind_monitor"] = thread
+
+        return process
+
+    def start_websocket_server(self, websocket_server, loop) -> threading.Thread:
+        def run():
+            asyncio.set_event_loop(loop)
+            loop.run_until_complete(websocket_server.start())
+            try:
+                while not self.shutdown_event.is_set():
+                    loop.run_until_complete(asyncio.sleep(0.1))
+            except Exception:
+                pass
+            finally:
+                loop.run_until_complete(websocket_server.stop())
+
+        thread = threading.Thread(target=run, daemon=True)
+        thread.start()
+        self.threads["websocket"] = thread
+        console.print("[green]WebSocket server started on port 5001[/green]")
+        return thread
+
+    def is_running(self, name: str) -> bool:
+        return name in self.processes and self.processes[name].poll() is None
+
+    def stop_process(self, name: str, timeout: int = 2) -> bool:
+        if name not in self.processes:
+            return True
+
+        process = self.processes[name]
+        try:
+            process.terminate()
+            process.wait(timeout=timeout)
+        except subprocess.TimeoutExpired:
+            process.kill()
+            process.wait(timeout=1)
+        except Exception:
+            pass
+
+        self.processes.pop(name, None)
+        return True
+
+    def stop_all(self, timeout: int = 2):
+        if self.shutdown_event.is_set():
+            return  # Already shutting down
+
+        self.shutdown_event.set()
+
+        # Stop processes in parallel for speed
+        for name in list(self.processes):
+            self.stop_process(name, timeout)
+
+        # Don't wait for threads, they're daemon threads
+        self.processes.clear()
+        self.threads.clear()
+
+    def wait_for_any_exit(self):
+        while not self.shutdown_event.is_set():
+            dead = []
+            for name, proc in self.processes.items():
+                if proc.poll() is not None:
+                    if name == "tailwind" and proc.returncode == 0:
+                        continue
+                    dead.append(name)
+
+            if dead:
+                for name in dead:
+                    console.print(f"[red]{name} died unexpectedly[/red]")
+                    del self.processes[name]
+                if "uvicorn" in dead:
+                    break
+
+            time.sleep(0.5)

--- a/src/starui/dev/process_manager.py
+++ b/src/starui/dev/process_manager.py
@@ -62,13 +62,13 @@ class ProcessManager:
         port: int,
         watch_patterns: list[str] = None,
         enable_css_hot_reload: bool = True,
+        css_ws_port: int = 5001,
     ) -> subprocess.Popen:
         if enable_css_hot_reload:
-            wrapper_file = app_file.parent / f"{app_file.stem}_dev.py"
-            if not wrapper_file.exists():
-                wrapper_file.write_text(f"""from {app_file.stem} import app as original_app
+            wrapper_file = app_file.parent / f"{app_file.stem}_dev_{css_ws_port}.py"
+            wrapper_file.write_text(f"""from {app_file.stem} import app as original_app
 from starui.dev.middleware import CSSHotReloadMiddleware
-app = CSSHotReloadMiddleware(original_app)""")
+app = CSSHotReloadMiddleware(original_app, ws_port={css_ws_port})""")
             app_module = f"{wrapper_file.stem}:app"
         else:
             app_module = f"{app_file.stem}:app"
@@ -163,7 +163,9 @@ app = CSSHotReloadMiddleware(original_app)""")
         thread = threading.Thread(target=run, daemon=True)
         thread.start()
         self.threads["websocket"] = thread
-        console.print("[green]WebSocket server started on port 5001[/green]")
+        console.print(
+            f"[green]WebSocket server started on port {websocket_server.port}[/green]"
+        )
         return thread
 
     def is_running(self, name: str) -> bool:

--- a/src/starui/dev/websocket_server.py
+++ b/src/starui/dev/websocket_server.py
@@ -1,0 +1,66 @@
+"""WebSocket server for CSS hot reload."""
+
+import asyncio
+import json
+from pathlib import Path
+
+import websockets
+from websockets.server import WebSocketServerProtocol
+
+
+class CSSHotReloadServer:
+    """WebSocket server for CSS hot reload notifications."""
+
+    def __init__(self, port: int = 5001):
+        self.port = port
+        self.clients: set[WebSocketServerProtocol] = set()
+        self.server = None
+
+    async def notify_css_update(self, css_path: Path, build_time: float = 0) -> None:
+        """Notify all clients about CSS update."""
+        if not self.clients:
+            return
+
+        message = json.dumps(
+            {
+                "type": "css-update",
+                "path": str(css_path),
+                "timestamp": asyncio.get_event_loop().time(),
+                "buildTime": build_time,
+            }
+        )
+
+        disconnected = set()
+        for client in self.clients:
+            try:
+                await client.send(message)
+            except websockets.exceptions.ConnectionClosed:
+                disconnected.add(client)
+            except Exception:
+                disconnected.add(client)
+
+        self.clients -= disconnected
+
+    async def handle_client(
+        self, websocket: WebSocketServerProtocol, path: str
+    ) -> None:
+        """Handle a client WebSocket connection."""
+        self.clients.add(websocket)
+        try:
+            await websocket.send(json.dumps({"type": "connected"}))
+            async for _ in websocket:
+                pass  # Keep connection alive
+        except websockets.exceptions.ConnectionClosed:
+            pass
+        finally:
+            self.clients.discard(websocket)
+
+    async def start(self) -> None:
+        """Start the WebSocket server."""
+        self.server = await websockets.serve(self.handle_client, "localhost", self.port)
+
+    async def stop(self) -> None:
+        """Stop the WebSocket server."""
+        if self.server:
+            self.server.close()
+            await self.server.wait_closed()


### PR DESCRIPTION
## Summary
- Implements CSS hot reload via WebSocket for instant CSS updates without page refresh
- Uses separate process architecture: uvicorn + Tailwind CLI --watch + CSS WebSocket server
- Auto-injects CSS hot reload script via ASGI middleware (no manual app.py changes needed)
- Fixes clean single Ctrl+C shutdown and process cleanup
- Maintains full compatibility with StarHTML's existing live reload

## Key Features
- **Python changes** → full browser reload (via StarHTML's `/live-reload` WebSocket)
- **CSS changes** → instant hot-swap (via StarUI's `/css-hot-reload` WebSocket on port 5001)
- **Auto-injection** → CSS hot reload script automatically added to HTML responses
- **Clean shutdown** → Single Ctrl+C properly terminates all processes

## Technical Implementation
- `CSSHotReloadMiddleware`: ASGI middleware for automatic script injection
- `ProcessManager`: Coordinates uvicorn, Tailwind CLI, and WebSocket server
- `CSSHotReloadServer`: WebSocket server for CSS update notifications
- Temporary wrapper files for middleware integration during development

## Test plan
- [x] Python file changes trigger full page reload
- [x] Tailwind class changes trigger CSS hot-swap  
- [x] CSS hot reload script auto-injected into HTML
- [x] Single Ctrl+C cleanly shuts down all processes
- [x] Both WebSocket systems work without interference
- [x] All code passes ruff linting and pyright type checking