### PR TITLE
Add AlertDialog component

### DIFF
--- a/docs/pyproject.toml
+++ b/docs/pyproject.toml
@@ -5,7 +5,7 @@ description = "Documentation for StarUI component library"
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
-    "starhtml>=0.1.13",
+    "starhtml>=0.1.14",
     "starlighter>=0.1.5",
     "starui>=0.1.7",
     "uvicorn>=0.30.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "requests>=2.31.0,<3.0.0",
     "pydantic>=2.5.0,<3.0.0",
     "rich>=13.7.0,<14.0.0",
-    "starhtml==0.1.13",
+    "starhtml==0.1.14",
 ]
 
 # Optional dependencies for development - using dependency-groups below for UV compatibility

--- a/src/starui/registry/component_metadata.py
+++ b/src/starui/registry/component_metadata.py
@@ -35,6 +35,9 @@ def _component(
 
 COMPONENT_REGISTRY = {
     "accordion": _component("accordion", "Collapsible content sections", ["utils"]),
+    "alert_dialog": _component(
+        "alert_dialog", "Alert dialog for confirmations", ["utils", "button"]
+    ),
     "code_block": _component(
         "code_block",
         "Code block with syntax highlighting",

--- a/src/starui/registry/components/alert_dialog.py
+++ b/src/starui/registry/components/alert_dialog.py
@@ -1,0 +1,180 @@
+from typing import Any, Literal
+
+from starhtml import FT, Div
+from starhtml import H2 as HTMLH2
+from starhtml import Dialog as HTMLDialog
+from starhtml import P as HTMLP
+from starhtml.datastar import ds_effect, ds_on_click, ds_on_close, ds_ref, ds_signals
+
+from .utils import cn
+
+AlertDialogVariant = Literal["default", "destructive"]
+
+
+def AlertDialog(
+    trigger: FT,
+    content: FT,
+    ref_id: str,
+    class_name: str = "",
+    cls: str = "",
+    **attrs: Any,
+) -> FT:
+    signal_name = f"{ref_id}_open"
+
+    classes = cn(
+        "fixed max-h-[85vh] w-full max-w-lg overflow-auto m-auto bg-background text-foreground border border-input rounded-lg shadow-lg p-0 backdrop:bg-black/50 backdrop:backdrop-blur-sm open:animate-in open:fade-in-0 open:zoom-in-95 open:duration-200 open:backdrop:animate-in open:backdrop:fade-in-0 open:backdrop:duration-200",
+        class_name,
+        cls,
+    )
+
+    dialog_element = HTMLDialog(
+        content,
+        ds_ref(ref_id),
+        ds_on_close(f"${signal_name} = false"),
+        ds_on_click(f"""
+            evt.target === evt.currentTarget &&
+            (${ref_id}.close(), ${signal_name} = false)
+        """),
+        id=ref_id,
+        cls=classes,
+        **attrs,
+    )
+
+    scroll_lock = Div(
+        ds_signals(**{signal_name: False}),
+        ds_effect(f"document.body.style.overflow = ${signal_name} ? 'hidden' : ''"),
+        style="display: none;",
+    )
+
+    return Div(trigger, dialog_element, scroll_lock)
+
+
+def AlertDialogTrigger(
+    *children: Any,
+    ref_id: str,
+    variant: str = "default",
+    class_name: str = "",
+    cls: str = "",
+    **attrs: Any,
+) -> FT:
+    from .button import Button
+
+    return Button(
+        *children,
+        ds_on_click(f"${ref_id}.showModal(), ${ref_id}_open = true"),
+        aria_haspopup="dialog",
+        variant=variant,
+        cls=cn(class_name, cls),
+        **attrs,
+    )
+
+
+def AlertDialogContent(
+    *children: Any,
+    class_name: str = "",
+    cls: str = "",
+    **attrs: Any,
+) -> FT:
+    return Div(
+        *children,
+        cls=cn("relative p-6", class_name, cls),
+        **attrs,
+    )
+
+
+def AlertDialogHeader(
+    *children: Any,
+    class_name: str = "",
+    cls: str = "",
+    **attrs: Any,
+) -> FT:
+    return Div(
+        *children,
+        cls=cn("flex flex-col gap-2 text-center sm:text-left", class_name, cls),
+        **attrs,
+    )
+
+
+def AlertDialogFooter(
+    *children: Any,
+    class_name: str = "",
+    cls: str = "",
+    **attrs: Any,
+) -> FT:
+    return Div(
+        *children,
+        cls=cn(
+            "flex flex-col-reverse gap-2 sm:flex-row sm:justify-end mt-6",
+            class_name,
+            cls,
+        ),
+        **attrs,
+    )
+
+
+def AlertDialogTitle(
+    *children: Any,
+    class_name: str = "",
+    cls: str = "",
+    **attrs: Any,
+) -> FT:
+    return HTMLH2(
+        *children,
+        cls=cn("text-lg leading-none font-semibold text-foreground", class_name, cls),
+        **attrs,
+    )
+
+
+def AlertDialogDescription(
+    *children: Any,
+    class_name: str = "",
+    cls: str = "",
+    **attrs: Any,
+) -> FT:
+    return HTMLP(
+        *children,
+        cls=cn("text-muted-foreground text-sm", class_name, cls),
+        **attrs,
+    )
+
+
+def AlertDialogAction(
+    *children: Any,
+    ref_id: str,
+    action: str = "",
+    variant: AlertDialogVariant = "default",
+    class_name: str = "",
+    cls: str = "",
+    **attrs: Any,
+) -> FT:
+    from .button import Button
+
+    close_expr = f"${ref_id}_open = false, ${ref_id}.close()"
+    if action:
+        close_expr = f"{action}, {close_expr}"
+
+    return Button(
+        *children,
+        ds_on_click(close_expr),
+        variant="destructive" if variant == "destructive" else "default",
+        cls=cn(class_name, cls),
+        **attrs,
+    )
+
+
+def AlertDialogCancel(
+    *children: Any,
+    ref_id: str,
+    class_name: str = "",
+    cls: str = "",
+    **attrs: Any,
+) -> FT:
+    from .button import Button
+
+    return Button(
+        *children,
+        ds_on_click(f"${ref_id}_open = false, ${ref_id}.close()"),
+        variant="outline",
+        cls=cn(class_name, cls),
+        **attrs,
+    )

--- a/src/starui/registry/components/dialog.py
+++ b/src/starui/registry/components/dialog.py
@@ -14,7 +14,7 @@ from starhtml import (
     Dialog as HTMLDialog,
 )
 from starhtml import P as HTMLP
-from starhtml.datastar import ds_effect, ds_on, ds_on_click, ds_ref, ds_signals
+from starhtml.datastar import ds_effect, ds_on_click, ds_on_close, ds_ref, ds_signals
 
 from .utils import cn, cva
 
@@ -22,7 +22,7 @@ DialogSize = Literal["sm", "md", "lg", "xl", "full"]
 
 
 dialog_variants = cva(
-    base="fixed max-h-[85vh] w-full overflow-auto m-auto bg-background text-foreground border rounded-lg shadow-lg p-0 backdrop:bg-black/50 backdrop:backdrop-blur-sm open:animate-in open:fade-in-0 open:zoom-in-95 open:duration-200 open:backdrop:animate-in open:backdrop:fade-in-0 open:backdrop:duration-200",
+    base="fixed max-h-[85vh] w-full overflow-auto m-auto bg-background text-foreground border border-input rounded-lg shadow-lg p-0 backdrop:bg-black/50 backdrop:backdrop-blur-sm open:animate-in open:fade-in-0 open:zoom-in-95 open:duration-200 open:backdrop:animate-in open:backdrop:fade-in-0 open:backdrop:duration-200",
     config={
         "variants": {
             "size": {
@@ -52,7 +52,7 @@ def Dialog(
 
     classes = cn(dialog_variants(size=size), class_name, cls)
 
-    dialog_attrs = [ds_ref(ref_id), ds_on("close", f"${signal_name} = false")]
+    dialog_attrs = [ds_ref(ref_id), ds_on_close(f"${signal_name} = false")]
 
     if modal:
         dialog_attrs.append(

--- a/test_sandbox/app.py
+++ b/test_sandbox/app.py
@@ -338,7 +338,7 @@ def index():
             ),
             # Dialog with different size and content
             Div(
-                H2("Alert Dialog", cls="text-2xl font-semibold mb-4"),
+                H2("Dialog (Small Size)", cls="text-2xl font-semibold mb-4"),
                 Dialog(
                     trigger=DialogTrigger(
                         "Delete Account", ref_id="delete-dialog", variant="destructive"
@@ -358,6 +358,90 @@ def index():
                     ),
                     ref_id="delete-dialog",
                     size="sm",
+                ),
+                cls="mb-8",
+            ),
+            # Alert Dialog examples
+            Div(
+                H2("Alert Dialog", cls="text-2xl font-semibold mb-4"),
+                Div(
+                    # Basic alert dialog
+                    AlertDialog(
+                        trigger=AlertDialogTrigger(
+                            "Show Alert", 
+                            ref_id="basic_alert"
+                        ),
+                        content=AlertDialogContent(
+                            AlertDialogHeader(
+                                AlertDialogTitle("Are you absolutely sure?"),
+                                AlertDialogDescription(
+                                    "This action cannot be undone. This will permanently delete your "
+                                    "account and remove your data from our servers."
+                                ),
+                            ),
+                            AlertDialogFooter(
+                                AlertDialogCancel("Cancel", ref_id="basic_alert"),
+                                AlertDialogAction(
+                                    "Continue",
+                                    ref_id="basic_alert",
+                                    action="console.log('Action confirmed!')",
+                                ),
+                            ),
+                        ),
+                        ref_id="basic_alert",
+                    ),
+                    # Destructive alert dialog
+                    AlertDialog(
+                        trigger=AlertDialogTrigger(
+                            "Delete Item", 
+                            ref_id="destructive_alert",
+                            variant="destructive"
+                        ),
+                        content=AlertDialogContent(
+                            AlertDialogHeader(
+                                AlertDialogTitle("Delete Item"),
+                                AlertDialogDescription(
+                                    "Are you sure you want to delete this item? This action is irreversible."
+                                ),
+                            ),
+                            AlertDialogFooter(
+                                AlertDialogCancel("Cancel", ref_id="destructive_alert"),
+                                AlertDialogAction(
+                                    "Delete",
+                                    ref_id="destructive_alert",
+                                    variant="destructive",
+                                    action="console.log('Item deleted!')",
+                                ),
+                            ),
+                        ),
+                        ref_id="destructive_alert",
+                    ),
+                    # Alert dialog with custom action
+                    AlertDialog(
+                        trigger=AlertDialogTrigger(
+                            "Confirm Action", 
+                            ref_id="custom_alert",
+                            variant="outline"
+                        ),
+                        content=AlertDialogContent(
+                            AlertDialogHeader(
+                                AlertDialogTitle("Confirm Action"),
+                                AlertDialogDescription(
+                                    "This will apply the changes you've made. Do you want to proceed?"
+                                ),
+                            ),
+                            AlertDialogFooter(
+                                AlertDialogCancel("Not now", ref_id="custom_alert"),
+                                AlertDialogAction(
+                                    "Yes, apply changes",
+                                    ref_id="custom_alert",
+                                    action="alert('Changes applied successfully!')",
+                                ),
+                            ),
+                        ),
+                        ref_id="custom_alert",
+                    ),
+                    cls="flex flex-wrap gap-4",
                 ),
                 cls="mb-8",
             ),


### PR DESCRIPTION
## Summary
- Added AlertDialog component for confirmation dialogs
- Updated Dialog and AlertDialog to use new `ds_on_close` helper from starhtml 0.1.14
- Fixed border styling to use `border-input` for proper theming

## Changes
- New `alert_dialog.py` component with full shadcn/ui API compatibility
- Updated `component_metadata.py` to register AlertDialog
- Added AlertDialog examples to test sandbox
- Updated starhtml to 0.1.14 for `ds_on_close` support
- Fixed border styling in Dialog and AlertDialog components

## Test plan
- [x] All tests pass (`pytest -v`)
- [x] Ruff formatting and linting pass
- [x] Component renders correctly in test sandbox
- [x] Scroll lock functionality works properly
- [x] Dialog closes correctly via ESC, backdrop click, and buttons