### PR TITLE
feat: Add Avatar component

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,48 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- **✨ New Components**
+  - Added `Avatar` component with image fallback support using Datastar reactivity
+  - Added `Accordion` component with collapsible content sections
+  - Added `Toggle` and `ToggleGroup` components for toggle button functionality
+  - Added `Progress` component with determinate and indeterminate states
+  - Added `Separator` component for visual content separation
+
+- **📚 Documentation Site**
+  - Launched comprehensive documentation site with live component previews
+  - Added interactive component playground with code examples
+  - Implemented syntax highlighting for code snippets
+  - Created component API reference documentation
+
+### Changed
+- **🎨 Avatar Component Design**
+  - Simplified Avatar API to match ShadCN's minimalist approach (4 core components)
+  - Moved complex patterns (groups, badges, colored initials) to composition examples
+  - Reduced component size from 256 lines to 107 lines for better maintainability
+  
+- **🔧 Tabs Component Refactor**
+  - Made Tabs component more semantic with id-based approach
+  - Improved accessibility with proper ARIA attributes
+  - Enhanced keyboard navigation support
+
+- **🔥 Live Reload & Build System**
+  - Rewrote watchdog implementation for better CSS change detection
+  - Enhanced file watcher to properly track CSS modifications during development
+  - Fixed hot-reload reliability for style changes
+  - Improved CSS build pipeline for faster development feedback
+
+### Fixed
+- **🐛 Component Issues**
+  - Fixed Avatar fallback mechanism to properly show on image load errors
+  - Resolved Datastar attribute handling in Avatar components
+  - Fixed contrast issues with auto-generated avatar colors in light/dark modes
+  
+- **🔄 Development Experience**
+  - Fixed live reload not triggering on CSS changes
+  - Resolved watchdog file system event handling for style updates
+  - Fixed CSS compilation race conditions during hot reload
+
 ## [0.1.7] - 2025-08-30
 
 ### Added

--- a/docs/pages/components/avatar.py
+++ b/docs/pages/components/avatar.py
@@ -1,0 +1,432 @@
+"""
+Avatar component documentation - User profile images with fallback.
+Clean, minimal, and reactive.
+"""
+
+# Component metadata for auto-discovery
+TITLE = "Avatar"
+DESCRIPTION = "An image element with a fallback for representing the user."
+CATEGORY = "ui"
+ORDER = 15
+STATUS = "stable"
+
+from starhtml import Div, P, Span
+from starui.registry.components.avatar import (
+    Avatar,
+    AvatarFallback,
+    AvatarImage,
+    AvatarWithFallback,
+)
+from widgets.component_preview import ComponentPreview
+
+
+def examples():
+    """Generate avatar examples using ComponentPreview with tabs."""
+    
+    # Basic composition
+    yield ComponentPreview(
+        Div(
+            Avatar(
+                AvatarImage(
+                    src="https://github.com/shadcn.png",
+                    alt="@shadcn",
+                )
+            ),
+            Avatar(
+                AvatarFallback("CN")
+            ),
+            Avatar(
+                AvatarImage(
+                    src="https://avatars.githubusercontent.com/u/1?v=4",
+                    alt="User",
+                )
+            ),
+            cls="flex items-center gap-4"
+        ),
+        '''Avatar(
+    AvatarImage(
+        src="https://github.com/shadcn.png",
+        alt="@shadcn"
+    )
+)
+
+Avatar(
+    AvatarFallback("CN")
+)''',
+        title="Basic Avatar",
+        description="Compose avatars with image and fallback components"
+    )
+    
+    # Sizes using custom classes
+    yield ComponentPreview(
+        Div(
+            Avatar(AvatarFallback("XS"), cls="size-6"),
+            Avatar(AvatarFallback("SM"), cls="size-8"),
+            Avatar(AvatarFallback("MD")),  # default size-10
+            Avatar(AvatarFallback("LG"), cls="size-12"),
+            Avatar(AvatarFallback("XL"), cls="size-16"),
+            Avatar(AvatarFallback("2X"), cls="size-20"),
+            cls="flex items-center gap-4"
+        ),
+        '''# Extra small
+Avatar(AvatarFallback("XS"), cls="size-6")
+
+# Small
+Avatar(AvatarFallback("SM"), cls="size-8")
+
+# Default
+Avatar(AvatarFallback("MD"))
+
+# Large
+Avatar(AvatarFallback("LG"), cls="size-12")
+
+# Extra large
+Avatar(AvatarFallback("XL"), cls="size-16")
+
+# 2X large
+Avatar(AvatarFallback("2X"), cls="size-20")''',
+        title="Avatar Sizes",
+        description="Use size classes to create different avatar sizes"
+    )
+    
+    # With Fallback
+    yield ComponentPreview(
+        Div(
+            Avatar(AvatarFallback("CN")),
+            Avatar(AvatarFallback("JD")),
+            Avatar(AvatarFallback("AB")),
+            cls="flex items-center gap-4"
+        ),
+        '''Avatar(AvatarFallback("CN"))
+Avatar(AvatarFallback("JD"))
+Avatar(AvatarFallback("AB"))''',
+        title="Avatar Fallback",
+        description="Display initials when no image is available"
+    )
+    
+    # Automatic Fallback with Datastar
+    yield ComponentPreview(
+        Div(
+            Div(
+                AvatarWithFallback(
+                    src="https://github.com/shadcn.png",
+                    alt="@shadcn",
+                    fallback="CN",
+                ),
+                P("Valid URL", cls="text-xs text-muted-foreground text-center mt-1"),
+                cls="flex flex-col items-center"
+            ),
+            Div(
+                AvatarWithFallback(
+                    src="https://invalid-url.com/image.jpg",
+                    alt="Invalid",
+                    fallback="IN",
+                ),
+                P("Invalid URL", cls="text-xs text-muted-foreground text-center mt-1"),
+                cls="flex flex-col items-center"
+            ),
+            Div(
+                AvatarWithFallback(fallback="NI"),
+                P("No URL", cls="text-xs text-muted-foreground text-center mt-1"),
+                cls="flex flex-col items-center"
+            ),
+            cls="flex items-start gap-4"
+        ),
+        '''# Valid image with fallback ready
+AvatarWithFallback(
+    src="https://github.com/shadcn.png",
+    alt="@shadcn",
+    fallback="CN"
+)
+
+# Invalid URL - will show fallback
+AvatarWithFallback(
+    src="https://invalid-url.com/image.jpg",
+    alt="Invalid", 
+    fallback="IN"
+)
+
+# No image - shows fallback immediately
+AvatarWithFallback(fallback="NI")''',
+        title="Automatic Fallback",
+        description="Uses Datastar signals to automatically show fallback when image fails"
+    )
+    
+    # Avatar Group Pattern
+    yield ComponentPreview(
+        Div(
+            # Basic group
+            Div(
+                Avatar(AvatarFallback("JD")),
+                Avatar(AvatarFallback("AS")),
+                Avatar(AvatarFallback("PQ")),
+                Avatar(AvatarFallback("+2", cls="text-xs font-medium")),
+                cls="flex -space-x-2 [&>*[data-slot=avatar]]:ring-2 [&>*[data-slot=avatar]]:ring-background"
+            ),
+            cls="mb-4"
+        ),
+        '''# Avatar group with overlap
+Div(
+    Avatar(AvatarFallback("JD")),
+    Avatar(AvatarFallback("AS")),
+    Avatar(AvatarFallback("PQ")),
+    Avatar(AvatarFallback("+2", cls="text-xs font-medium")),
+    cls="flex -space-x-2 [&>*[data-slot=avatar]]:ring-2 [&>*[data-slot=avatar]]:ring-background"
+)''',
+        title="Avatar Group",
+        description="Create overlapping avatar groups with Tailwind utilities"
+    )
+    
+    # With Badge Pattern
+    yield ComponentPreview(
+        Div(
+            # Green status badge
+            Div(
+                Avatar(AvatarFallback("JD")),
+                Span(cls="absolute bottom-0 right-0 size-3 bg-green-500 rounded-full ring-2 ring-background"),
+                cls="relative inline-block"
+            ),
+            # Red status badge
+            Div(
+                Avatar(AvatarFallback("AS")),
+                Span(cls="absolute bottom-0 right-0 size-3 bg-red-500 rounded-full ring-2 ring-background"),
+                cls="relative inline-block"
+            ),
+            # Yellow status badge
+            Div(
+                Avatar(AvatarFallback("PQ")),
+                Span(cls="absolute bottom-0 right-0 size-3 bg-yellow-500 rounded-full ring-2 ring-background"),
+                cls="relative inline-block"
+            ),
+            # Badge with count
+            Div(
+                Avatar(AvatarFallback("MN")),
+                Span("5", cls="absolute bottom-0 right-0 size-4 bg-red-500 rounded-full ring-2 ring-background flex items-center justify-center text-[8px] font-bold text-white"),
+                cls="relative inline-block"
+            ),
+            cls="flex items-center gap-4"
+        ),
+        '''# Status indicator
+Div(
+    Avatar(AvatarFallback("JD")),
+    Span(cls="absolute bottom-0 right-0 size-3 bg-green-500 rounded-full ring-2 ring-background"),
+    cls="relative inline-block"
+)
+
+# Notification badge with count
+Div(
+    Avatar(AvatarFallback("MN")),
+    Span(
+        "5",
+        cls="absolute bottom-0 right-0 size-4 bg-red-500 rounded-full ring-2 ring-background flex items-center justify-center text-[8px] font-bold text-white"
+    ),
+    cls="relative inline-block"
+)''',
+        title="Avatar with Badge",
+        description="Add status indicators or notification badges using absolute positioning"
+    )
+    
+    # Colored Initials Pattern
+    yield ComponentPreview(
+        Div(
+            Avatar(AvatarFallback("JD", cls="bg-red-600 dark:bg-red-500 text-white font-semibold")),
+            Avatar(AvatarFallback("AS", cls="bg-blue-600 dark:bg-blue-500 text-white font-semibold")),
+            Avatar(AvatarFallback("PQ", cls="bg-green-600 dark:bg-green-500 text-white font-semibold")),
+            Avatar(AvatarFallback("MN", cls="bg-purple-600 dark:bg-purple-500 text-white font-semibold")),
+            Avatar(AvatarFallback("XY", cls="bg-orange-600 dark:bg-orange-500 text-white font-semibold")),
+            cls="flex items-center gap-4"
+        ),
+        '''# Colored initials with theme support
+Avatar(
+    AvatarFallback(
+        "JD",
+        cls="bg-red-600 dark:bg-red-500 text-white font-semibold"
+    )
+)
+
+Avatar(
+    AvatarFallback(
+        "AS",
+        cls="bg-blue-600 dark:bg-blue-500 text-white font-semibold"
+    )
+)''',
+        title="Colored Initials",
+        description="Create colorful initial avatars with theme-aware backgrounds"
+    )
+
+
+def create_avatar_docs():
+    """Create the Avatar component documentation page."""
+    from utils import auto_generate_page
+    
+    api_reference = {
+        "components": [
+            {
+                "name": "Avatar",
+                "description": "Container component for avatar content",
+                "props": [
+                    {
+                        "name": "class_name / cls",
+                        "type": "str",
+                        "default": "''",
+                        "description": "Additional CSS classes for customization"
+                    },
+                    {
+                        "name": "*children",
+                        "type": "Any",
+                        "description": "Avatar content (usually AvatarImage or AvatarFallback)"
+                    }
+                ]
+            },
+            {
+                "name": "AvatarImage",
+                "description": "The image element for the avatar",
+                "props": [
+                    {
+                        "name": "src",
+                        "type": "str",
+                        "required": True,
+                        "description": "Image source URL"
+                    },
+                    {
+                        "name": "alt",
+                        "type": "str",
+                        "default": "''",
+                        "description": "Alt text for accessibility"
+                    },
+                    {
+                        "name": "loading",
+                        "type": "str",
+                        "default": "'lazy'",
+                        "description": "Loading strategy ('lazy' or 'eager')"
+                    }
+                ]
+            },
+            {
+                "name": "AvatarFallback",
+                "description": "Fallback content shown when image fails to load",
+                "props": [
+                    {
+                        "name": "*children",
+                        "type": "Any",
+                        "description": "Content to display (usually initials)"
+                    },
+                    {
+                        "name": "class_name / cls",
+                        "type": "str",
+                        "default": "''",
+                        "description": "Additional CSS classes"
+                    }
+                ]
+            },
+            {
+                "name": "AvatarWithFallback",
+                "description": "Complete avatar with automatic error handling",
+                "props": [
+                    {
+                        "name": "src",
+                        "type": "Optional[str]",
+                        "default": "None",
+                        "description": "Optional image source URL"
+                    },
+                    {
+                        "name": "alt",
+                        "type": "str",
+                        "default": "''",
+                        "description": "Alt text"
+                    },
+                    {
+                        "name": "fallback",
+                        "type": "str",
+                        "default": "'?'",
+                        "description": "Fallback text/initials"
+                    }
+                ]
+            }
+        ]
+    }
+    
+    # Hero example showing diverse avatar types
+    hero_example = ComponentPreview(
+        Div(
+            # Regular avatars with images
+            Avatar(
+                AvatarImage(
+                    src="https://github.com/shadcn.png",
+                    alt="@shadcn"
+                )
+            ),
+            Avatar(
+                AvatarImage(
+                    src="https://avatars.githubusercontent.com/u/2?v=4",
+                    alt="User 2"
+                )
+            ),
+            # Fallback avatars
+            Avatar(AvatarFallback("CN")),
+            # Colored initials
+            Avatar(AvatarFallback("JD", cls="bg-red-600 dark:bg-red-500 text-white font-semibold")),
+            Avatar(AvatarFallback("AS", cls="bg-blue-600 dark:bg-blue-500 text-white font-semibold")),
+            # With badge
+            Div(
+                Avatar(
+                    AvatarImage(
+                        src="https://avatars.githubusercontent.com/u/3?v=4",
+                        alt="User 3"
+                    )
+                ),
+                Span(cls="absolute bottom-0 right-0 size-3 bg-green-500 rounded-full ring-2 ring-background"),
+                cls="relative inline-block"
+            ),
+            Div(
+                Avatar(AvatarFallback("MN")),
+                Span("3", cls="absolute bottom-0 right-0 size-4 bg-red-500 rounded-full ring-2 ring-background flex items-center justify-center text-[8px] font-bold text-white"),
+                cls="relative inline-block"
+            ),
+            # Group
+            Div(
+                Avatar(AvatarFallback("A", cls="text-xs")),
+                Avatar(AvatarFallback("B", cls="text-xs")),
+                Avatar(AvatarFallback("+2", cls="text-xs font-medium")),
+                cls="flex -space-x-3 [&>*[data-slot=avatar]]:ring-2 [&>*[data-slot=avatar]]:ring-background [&>*[data-slot=avatar]]:size-8"
+            ),
+            cls="flex items-center gap-3 flex-wrap justify-center"
+        ),
+        '''# Basic avatars
+Avatar(AvatarImage(src="...", alt="..."))
+Avatar(AvatarFallback("CN"))
+
+# Colored initials
+Avatar(
+    AvatarFallback(
+        "JD",
+        cls="bg-red-600 dark:bg-red-500 text-white font-semibold"
+    )
+)
+
+# With status badge
+Div(
+    Avatar(AvatarImage(...)),
+    Span(cls="absolute bottom-0 right-0 size-3 bg-green-500 rounded-full ring-2 ring-background"),
+    cls="relative inline-block"
+)
+
+# Grouped avatars
+Div(
+    Avatar(AvatarFallback("A")),
+    Avatar(AvatarFallback("B")),
+    Avatar(AvatarFallback("+2")),
+    cls="flex -space-x-3 [&>*[data-slot=avatar]]:ring-2 [&>*[data-slot=avatar]]:ring-background"
+)''',
+        copy_button=True
+    )
+    
+    return auto_generate_page(
+        TITLE,
+        DESCRIPTION,
+        list(examples()),
+        cli_command="star add avatar",
+        api_reference=api_reference,
+        hero_example=hero_example,
+        component_slug="avatar"
+    )

--- a/src/starui/registry/component_metadata.py
+++ b/src/starui/registry/component_metadata.py
@@ -38,6 +38,7 @@ COMPONENT_REGISTRY = {
     "alert_dialog": _component(
         "alert_dialog", "Alert dialog for confirmations", ["utils", "button"]
     ),
+    "avatar": _component("avatar", "User profile images with fallback", ["utils"]),
     "code_block": _component(
         "code_block",
         "Code block with syntax highlighting",

--- a/src/starui/registry/components/avatar.py
+++ b/src/starui/registry/components/avatar.py
@@ -1,0 +1,107 @@
+from typing import Any
+from uuid import uuid4
+
+from starhtml import FT, Div, Img
+from starhtml.datastar import ds_on, ds_show, ds_signals
+
+from .utils import cn
+
+
+def Avatar(
+    *children: Any,
+    class_name: str = "",
+    cls: str = "",
+    **attrs: Any,
+) -> FT:
+    """Avatar container component."""
+    return Div(
+        *children,
+        data_slot="avatar",
+        cls=cn(
+            "relative flex size-10 shrink-0 overflow-hidden rounded-full",
+            class_name,
+            cls,
+        ),
+        **attrs,
+    )
+
+
+def AvatarImage(
+    src: str,
+    alt: str = "",
+    loading: str = "lazy",
+    class_name: str = "",
+    cls: str = "",
+    **attrs: Any,
+) -> FT:
+    """Avatar image component."""
+    return Img(
+        src=src,
+        alt=alt,
+        loading=loading,
+        data_slot="avatar-image",
+        cls=cn("aspect-square size-full object-cover", class_name, cls),
+        **attrs,
+    )
+
+
+def AvatarFallback(
+    *children: Any,
+    class_name: str = "",
+    cls: str = "",
+    **attrs: Any,
+) -> FT:
+    """Avatar fallback component."""
+    has_bg = any("bg-" in str(c) for c in [class_name, cls])
+
+    return Div(
+        *children,
+        data_slot="avatar-fallback",
+        cls=cn(
+            "flex size-full items-center justify-center rounded-full",
+            "bg-muted" if not has_bg else "",
+            class_name,
+            cls,
+        ),
+        **attrs,
+    )
+
+
+def AvatarWithFallback(
+    src: str | None = None,
+    alt: str = "",
+    fallback: str = "?",
+    class_name: str = "",
+    cls: str = "",
+    **attrs: Any,
+) -> FT:
+    """Avatar with automatic fallback on image load error."""
+    if not src:
+        return Avatar(
+            AvatarFallback(fallback),
+            cls=cn(class_name, cls),
+            **attrs,
+        )
+
+    signal = f"avatar_{str(uuid4())[:8]}_error"
+
+    return Avatar(
+        ds_signals(**{signal: False}),
+        Img(
+            ds_show(f"!${signal}"),
+            ds_on("error", f"${signal} = true"),
+            src=src,
+            alt=alt,
+            loading="lazy",
+            cls="aspect-square size-full object-cover",
+            data_slot="avatar-image",
+        ),
+        Div(
+            fallback,
+            ds_show(f"${signal}"),
+            cls="flex size-full items-center justify-center rounded-full bg-muted",
+            data_slot="avatar-fallback",
+        ),
+        cls=cn(class_name, cls),
+        **attrs,
+    )

--- a/test_sandbox/app.py
+++ b/test_sandbox/app.py
@@ -1128,6 +1128,130 @@ def index():
                     cls="space-y-4 mb-8",
                 ),
             ),
+            # Avatar examples
+            Div(
+                H2("Avatars", cls="text-2xl font-semibold mb-4"),
+                Div(
+                    # Basic Avatar with image
+                    Div(
+                        H3("Basic Avatar", cls="text-lg font-medium mb-2"),
+                        Div(
+                            Avatar(
+                                AvatarImage(
+                                    src="https://github.com/shadcn.png",
+                                    alt="@shadcn"
+                                )
+                            ),
+                            Avatar(
+                                AvatarFallback("CN")
+                            ),
+                            Avatar(
+                                AvatarImage(
+                                    src="https://avatars.githubusercontent.com/u/1?v=4",
+                                    alt="User"
+                                )
+                            ),
+                            cls="flex gap-4 items-center"
+                        ),
+                        cls="mb-6",
+                    ),
+                    # Different sizes (composition example)
+                    Div(
+                        H3("Avatar Sizes", cls="text-lg font-medium mb-2"),
+                        P("Use size classes to customize:", cls="text-sm text-muted-foreground mb-2"),
+                        Div(
+                            Avatar(AvatarFallback("XS"), cls="size-6"),
+                            Avatar(AvatarFallback("SM"), cls="size-8"),
+                            Avatar(AvatarFallback("MD")),  # default size-10
+                            Avatar(AvatarFallback("LG"), cls="size-12"),
+                            Avatar(AvatarFallback("XL"), cls="size-16"),
+                            Avatar(AvatarFallback("2X"), cls="size-20"),
+                            cls="flex gap-4 items-center"
+                        ),
+                        cls="mb-6",
+                    ),
+                    # Avatar with automatic fallback
+                    Div(
+                        H3("Automatic Fallback", cls="text-lg font-medium mb-2"),
+                        P("The second avatar will show fallback as the image URL is invalid:", cls="text-sm text-muted-foreground mb-2"),
+                        Div(
+                            AvatarWithFallback(
+                                src="https://github.com/shadcn.png",
+                                alt="@shadcn",
+                                fallback="CN"
+                            ),
+                            AvatarWithFallback(
+                                src="https://invalid-url.com/image.jpg",
+                                alt="Invalid",
+                                fallback="IN"
+                            ),
+                            AvatarWithFallback(
+                                fallback="NI"
+                            ),
+                            cls="flex gap-4 items-center"
+                        ),
+                        cls="mb-6",
+                    ),
+                    # Avatar Group (composition example)
+                    Div(
+                        H3("Avatar Group", cls="text-lg font-medium mb-2"),
+                        P("Compose avatars with overlapping styles:", cls="text-sm text-muted-foreground mb-2"),
+                        Div(
+                            Div(
+                                Avatar(AvatarFallback("JD")),
+                                Avatar(AvatarFallback("AS")),
+                                Avatar(AvatarFallback("PQ")),
+                                Avatar(AvatarFallback("+2", cls="text-xs font-medium")),
+                                cls="flex -space-x-2 [&>*[data-slot=avatar]]:ring-2 [&>*[data-slot=avatar]]:ring-background"
+                            ),
+                            cls="mb-2"
+                        ),
+                        cls="mb-6",
+                    ),
+                    # Avatar with Badge (composition example)
+                    Div(
+                        H3("Avatar with Badge", cls="text-lg font-medium mb-2"),
+                        P("Compose with absolute positioning:", cls="text-sm text-muted-foreground mb-2"),
+                        Div(
+                            # Green status badge
+                            Div(
+                                Avatar(AvatarFallback("JD")),
+                                Span(cls="absolute bottom-0 right-0 size-3 bg-green-500 rounded-full ring-2 ring-background"),
+                                cls="relative inline-block"
+                            ),
+                            # Red status badge
+                            Div(
+                                Avatar(AvatarFallback("AS")),
+                                Span(cls="absolute bottom-0 right-0 size-3 bg-red-500 rounded-full ring-2 ring-background"),
+                                cls="relative inline-block"
+                            ),
+                            # Badge with count
+                            Div(
+                                Avatar(AvatarFallback("MN")),
+                                Span("5", cls="absolute bottom-0 right-0 size-4 bg-red-500 rounded-full ring-2 ring-background flex items-center justify-center text-[8px] font-bold text-white"),
+                                cls="relative inline-block"
+                            ),
+                            cls="flex gap-4 items-center"
+                        ),
+                        cls="mb-6",
+                    ),
+                    # Avatar from Initials (composition example)
+                    Div(
+                        H3("Avatar from Initials", cls="text-lg font-medium mb-2"),
+                        P("Use colored backgrounds for initials:", cls="text-sm text-muted-foreground mb-2"),
+                        Div(
+                            Avatar(AvatarFallback("JD", cls="bg-red-600 dark:bg-red-500 text-white font-semibold")),
+                            Avatar(AvatarFallback("AS", cls="bg-blue-600 dark:bg-blue-500 text-white font-semibold")),
+                            Avatar(AvatarFallback("PQ", cls="bg-green-600 dark:bg-green-500 text-white font-semibold")),
+                            Avatar(AvatarFallback("MN", cls="bg-purple-600 dark:bg-purple-500 text-white font-semibold")),
+                            Avatar(AvatarFallback("XY", cls="bg-orange-600 dark:bg-orange-500 text-white font-semibold")),
+                            cls="flex gap-4 items-center"
+                        ),
+                        cls="mb-6",
+                    ),
+                    cls="space-y-4 mb-8",
+                ),
+            ),
             # Separator examples
             Div(
                 H2("Separators", cls="text-2xl font-semibold mb-4"),


### PR DESCRIPTION
## Summary
- Adds a new Avatar component following ShadCN's minimalist design philosophy
- Implements automatic image fallback using Datastar reactivity
- Provides composition examples for common patterns (groups, badges, colored initials)

## Components Added
- `Avatar` - Container component for avatar content
- `AvatarImage` - Image element with lazy loading support  
- `AvatarFallback` - Fallback content when image unavailable
- `AvatarWithFallback` - Complete avatar with automatic error handling

## Design Decisions
- Kept API minimal with only 4 core components (matching ShadCN approach)
- Moved complex patterns to documentation as composition examples
- Component is ~100 lines vs 250+ lines for batteries-included approach
- Follows "primitives, not prescriptions" principle

## Testing
- ✅ All ruff checks pass
- ✅ Pyright type checking passes
- ✅ Tested in test_sandbox with various examples
- ✅ Documentation includes 7 comprehensive examples

## Changes
- Added avatar component to registry
- Updated test sandbox with composition examples
- Created documentation with API reference
- Updated CHANGELOG with recent features