### PR TITLE
Fix StarHTML live reload integration and improve dev server output

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,7 +23,7 @@ dependencies = [
     "requests>=2.31.0,<3.0.0",
     "pydantic>=2.5.0,<3.0.0",
     "rich>=13.7.0,<14.0.0",
-    "starhtml==0.1.13",
+    "starhtml==0.1.15",
     "websockets>=12.0.0,<13.0.0",
 ]
 

--- a/src/starui/dev/process_manager.py
+++ b/src/starui/dev/process_manager.py
@@ -21,15 +21,21 @@ class ProcessManager:
         self.shutdown = threading.Event()
         self.console = Console()
 
-    def start_process(self, name: str, cmd: list[str], cwd: Path = None, env: dict = None):
+    def start_process(
+        self, name: str, cmd: list[str], cwd: Path = None, env: dict = None
+    ):
         if existing := self.processes.get(name):
             self.console.print(f"[yellow]{name} already running[/yellow]")
             return existing
 
         proc = subprocess.Popen(
-            cmd, cwd=cwd, env=env,
-            stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
-            text=True, bufsize=1
+            cmd,
+            cwd=cwd,
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            bufsize=1,
         )
         self.processes[name] = proc
         self._monitor(name, proc)
@@ -45,7 +51,9 @@ class ProcessManager:
                             if name in ("uvicorn", "tailwind"):
                                 self.console.print(clean, highlight=False)
                             else:
-                                self.console.print(f"[dim cyan][{name}][/dim cyan] {clean}")
+                                self.console.print(
+                                    f"[dim cyan][{name}][/dim cyan] {clean}"
+                                )
                     else:
                         time.sleep(0.1)
 
@@ -53,13 +61,27 @@ class ProcessManager:
         thread.start()
         self.threads[f"{name}_monitor"] = thread
 
-    def start_uvicorn(self, app_file: Path, port: int, patterns: list[str],
-                      hot_reload: bool = True, debug: bool = True):
+    def start_uvicorn(
+        self,
+        app_file: Path,
+        port: int,
+        patterns: list[str],
+        hot_reload: bool = True,
+        debug: bool = True,
+    ):
         module = self._get_app_module(app_file, hot_reload, debug)
         cmd = [
-            sys.executable, "-m", "uvicorn", module,
-            "--reload", "--port", str(port),
-            "--host", "localhost", "--reload-delay", "0.1"
+            sys.executable,
+            "-m",
+            "uvicorn",
+            module,
+            "--reload",
+            "--port",
+            str(port),
+            "--host",
+            "localhost",
+            "--reload-delay",
+            "0.1",
         ]
 
         for pattern in patterns:
@@ -121,14 +143,23 @@ except Exception as e:
 app = original_app""")
         return f"{wrapper.stem}:app"
 
-    def start_tailwind_watcher(self, binary: Path, input_css: Path, output_css: Path,
-                              project_root: Path, on_rebuild: Callable = None):
+    def start_tailwind_watcher(
+        self,
+        binary: Path,
+        input_css: Path,
+        output_css: Path,
+        project_root: Path,
+        on_rebuild: Callable = None,
+    ):
         cmd = [
             str(binary),
-            "--input", str(input_css),
-            "--output", str(output_css),
+            "--input",
+            str(input_css),
+            "--output",
+            str(output_css),
             "--watch=always",
-            "--cwd", str(project_root),
+            "--cwd",
+            str(project_root),
         ]
         proc = self.start_process("tailwind", cmd, project_root)
 
@@ -187,7 +218,8 @@ app = original_app""")
     def wait_for_any_exit(self):
         while not self.shutdown.is_set():
             dead = [
-                name for name, proc in self.processes.items()
+                name
+                for name, proc in self.processes.items()
                 if proc.poll() is not None
                 # Tailwind exiting cleanly is expected
                 and not (name == "tailwind" and proc.returncode == 0)

--- a/src/starui/dev/process_manager.py
+++ b/src/starui/dev/process_manager.py
@@ -1,4 +1,4 @@
-"""Development process coordination."""
+"""Process coordination for development server."""
 
 import os
 import subprocess
@@ -6,250 +6,199 @@ import sys
 import threading
 import time
 from collections.abc import Callable
+from contextlib import suppress
 from pathlib import Path
-from typing import Any
 
 from rich.console import Console
+
+RELOAD_EXCLUDES = ["*.css", "static/**", "**/tmp*", "**/__pycache__/**", "*_dev.py"]
 
 
 class ProcessManager:
     def __init__(self):
-        self.processes: dict[str, subprocess.Popen] = {}
-        self.threads: dict[str, threading.Thread] = {}
-        self.shutdown_event = threading.Event()
+        self.processes = {}
+        self.threads = {}
+        self.shutdown = threading.Event()
         self.console = Console()
 
-    def start_process(
-        self,
-        name: str,
-        cmd: list[str],
-        cwd: Path | None = None,
-        env: dict[str, str] | None = None,
-    ) -> subprocess.Popen:
+    def start_process(self, name: str, cmd: list[str], cwd: Path = None, env: dict = None):
         if existing := self.processes.get(name):
             self.console.print(f"[yellow]{name} already running[/yellow]")
             return existing
 
-        self.console.print(f"[green]Starting {name}...[/green]")
-        process = subprocess.Popen(
-            cmd,
-            cwd=cwd,
-            env=env,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            text=True,
-            bufsize=1,
+        proc = subprocess.Popen(
+            cmd, cwd=cwd, env=env,
+            stdout=subprocess.PIPE, stderr=subprocess.STDOUT,
+            text=True, bufsize=1
         )
-        self.processes[name] = process
-        self._start_monitor(name, process)
-        return process
+        self.processes[name] = proc
+        self._monitor(name, proc)
+        return proc
 
-    def _start_monitor(self, name: str, process: subprocess.Popen) -> None:
-        def monitor():
-            try:
-                while process.poll() is None and not self.shutdown_event.is_set():
-                    if (line := process.stdout.readline()) and (clean := line.strip()):
-                        self.console.print(f"[dim cyan][{name}][/dim cyan] {clean}")
+    def _monitor(self, name: str, proc: subprocess.Popen):
+        def run():
+            with suppress(Exception):
+                while proc.poll() is None and not self.shutdown.is_set():
+                    if line := proc.stdout.readline():
+                        if clean := line.rstrip():
+                            # Let uvicorn/tailwind format their own output
+                            if name in ("uvicorn", "tailwind"):
+                                self.console.print(clean, highlight=False)
+                            else:
+                                self.console.print(f"[dim cyan][{name}][/dim cyan] {clean}")
                     else:
                         time.sleep(0.1)
-            except Exception as e:
-                self.console.print(f"[red]Error monitoring {name}: {e}[/red]")
 
-        thread = threading.Thread(target=monitor, daemon=True)
+        thread = threading.Thread(target=run, daemon=True)
         thread.start()
         self.threads[f"{name}_monitor"] = thread
 
-    def start_uvicorn(
-        self,
-        app_file: Path,
-        port: int,
-        watch_patterns: list[str] | None = None,
-        enable_css_hot_reload: bool = True,
-        force_debug: bool = True,
-    ) -> subprocess.Popen:
-        app_module = self._create_app_module(
-            app_file, enable_css_hot_reload, force_debug
-        )
-        cmd = self._build_uvicorn_cmd(app_module, port, watch_patterns)
-        return self.start_process(
-            "uvicorn", cmd, app_file.parent, env=os.environ.copy()
-        )
-
-    def _create_app_module(
-        self, app_file: Path, enable_hot_reload: bool, force_debug: bool = True
-    ) -> str:
-        if not enable_hot_reload:
-            return f"{app_file.stem}:app"
-
-        wrapper_file = app_file.parent / f"{app_file.stem}_dev.py"
-        wrapper_file.write_text(f"""from {app_file.stem} import app as original_app
-from starui.dev.unified_reload import create_dev_reload_route, DevReloadJs
-
-# Force debug mode to disable compression
-if hasattr(original_app, 'debug'):
-    original_app.debug = {force_debug}
-
-# Replace StarHTML's live reload with StarUI's enhanced system
-try:
-    # Remove existing live reload routes
-    if hasattr(original_app, 'routes'):
-        original_app.routes = [
-            route for route in original_app.routes
-            if not (hasattr(route, 'path') and route.path == '/live-reload')
-        ]
-
-    # Remove existing live reload JS from headers
-    if hasattr(original_app, 'hdrs') and original_app.hdrs:
-        original_app.hdrs = [
-            hdr for hdr in original_app.hdrs
-            if 'live-reload' not in str(hdr).lower()
-        ]
-    elif not hasattr(original_app, 'hdrs'):
-        original_app.hdrs = []
-
-    # Add StarUI's unified dev reload
-    original_app.hdrs.append(DevReloadJs())
-
-    dev_route = create_dev_reload_route()
-    if hasattr(original_app, 'routes'):
-        original_app.routes.append(dev_route)
-    elif hasattr(original_app, 'router') and hasattr(original_app.router, 'routes'):
-        original_app.router.routes.append(dev_route)
-
-    print("[StarUI] Replaced StarHTML live reload with unified dev reload system")
-
-except Exception as e:
-    print(f"Warning: Could not replace dev reload system: {{e}}")
-
-app = original_app""")
-        return f"{wrapper_file.stem}:app"
-
-    def _build_uvicorn_cmd(
-        self, app_module: str, port: int, watch_patterns: list[str] | None
-    ) -> list[str]:
+    def start_uvicorn(self, app_file: Path, port: int, patterns: list[str],
+                      hot_reload: bool = True, debug: bool = True):
+        module = self._get_app_module(app_file, hot_reload, debug)
         cmd = [
-            sys.executable,
-            "-m",
-            "uvicorn",
-            app_module,
-            "--reload",
-            "--port",
-            str(port),
-            "--host",
-            "localhost",
-            "--reload-delay",
-            "0.1",
+            sys.executable, "-m", "uvicorn", module,
+            "--reload", "--port", str(port),
+            "--host", "localhost", "--reload-delay", "0.1"
         ]
 
-        for pattern in watch_patterns or ["*.py", "*.html"]:
+        for pattern in patterns:
             cmd.extend(["--reload-include", pattern])
-
-        for exclude in [
-            "*.css",
-            "static/**",
-            "**/tmp*",
-            "**/__pycache__/**",
-            "*_dev.py",
-        ]:
+        for exclude in RELOAD_EXCLUDES:
             cmd.extend(["--reload-exclude", exclude])
 
-        return cmd
+        return self.start_process("uvicorn", cmd, app_file.parent, os.environ.copy())
 
-    def start_tailwind_watcher(
-        self,
-        tailwind_binary: Path,
-        input_css: Path,
-        output_css: Path,
-        project_root: Path,
-        on_rebuild: Callable[[Path], Any] | None = None,
-    ) -> subprocess.Popen:
-        cmd = [
-            str(tailwind_binary),
-            "--input",
-            str(input_css),
-            "--output",
-            str(output_css),
-            "--watch=always",
-            "--cwd",
-            str(project_root),
+    def _get_app_module(self, app_file: Path, hot_reload: bool, debug: bool):
+        if not hot_reload:
+            return f"{app_file.stem}:app"
+
+        wrapper = app_file.parent / f"{app_file.stem}_dev.py"
+        wrapper.write_text(f"""import sys
+from {app_file.stem} import app as original_app
+from starui.dev.unified_reload import create_dev_reload_route, DevReloadJs
+from starlette.routing import WebSocketRoute
+
+if hasattr(original_app, 'debug'):
+    original_app.debug = {debug}
+
+try:
+    router = getattr(original_app, 'router', original_app)
+
+    if hasattr(router, 'routes'):
+        router.routes = [
+            r for r in router.routes
+            if not (isinstance(r, WebSocketRoute) and r.path == '/live-reload')
         ]
-        process = self.start_process("tailwind", cmd, project_root)
+
+    if hasattr(original_app, 'hdrs'):
+        if isinstance(original_app.hdrs, list):
+            original_app.hdrs = [
+                h for h in original_app.hdrs
+                if 'live-reload' not in str(h).lower()
+                and 'LiveReloadJs' not in str(type(h).__name__)
+            ]
+        else:
+            original_app.hdrs = []
+    else:
+        original_app.hdrs = []
+
+    original_app.hdrs.append(DevReloadJs())
+    route = create_dev_reload_route()
+
+    if hasattr(router, 'routes'):
+        router.routes.append(route)
+    elif hasattr(router, 'mount'):
+        router.mount('/live-reload', route)
+
+    sys.stdout.write("[StarUI] ✓ Replaced StarHTML live reload with unified dev reload system\\n")
+    sys.stdout.flush()
+
+except Exception as e:
+    sys.stderr.write(f"[StarUI] Warning: Could not fully replace dev reload system: {{e}}\\n")
+    sys.stderr.flush()
+
+app = original_app""")
+        return f"{wrapper.stem}:app"
+
+    def start_tailwind_watcher(self, binary: Path, input_css: Path, output_css: Path,
+                              project_root: Path, on_rebuild: Callable = None):
+        cmd = [
+            str(binary),
+            "--input", str(input_css),
+            "--output", str(output_css),
+            "--watch=always",
+            "--cwd", str(project_root),
+        ]
+        proc = self.start_process("tailwind", cmd, project_root)
 
         if on_rebuild:
-            self._start_file_watcher(output_css, on_rebuild)
-        return process
+            self._watch(output_css, on_rebuild)
 
-    def _start_file_watcher(
-        self, file_path: Path, callback: Callable[[Path], Any]
-    ) -> None:
-        def monitor():
-            last_mtime = file_path.stat().st_mtime if file_path.exists() else 0
-            if last_mtime:
-                callback(file_path)  # Initial callback
+        return proc
 
-            while not self.shutdown_event.is_set():
-                try:
-                    if (
-                        file_path.exists()
-                        and (mtime := file_path.stat().st_mtime) > last_mtime
-                    ):
-                        last_mtime = mtime
-                        callback(file_path)
-                except Exception:
-                    pass
+    def _watch(self, path: Path, callback: Callable):
+        def run():
+            last = path.stat().st_mtime if path.exists() else 0
+            if last:
+                callback(path)  # Initial trigger
+
+            while not self.shutdown.is_set():
+                with suppress(Exception):
+                    if path.exists() and (mtime := path.stat().st_mtime) > last:
+                        last = mtime
+                        callback(path)
                 time.sleep(0.5)
 
-        thread = threading.Thread(target=monitor, daemon=True)
+        thread = threading.Thread(target=run, daemon=True)
         thread.start()
         self.threads["tailwind_monitor"] = thread
 
     def is_running(self, name: str) -> bool:
-        return (
-            process := self.processes.get(name)
-        ) is not None and process.poll() is None
+        return (p := self.processes.get(name)) and p.poll() is None
 
-    def stop_process(self, name: str, timeout: int = 2) -> bool:
-        if not (process := self.processes.get(name)):
+    def stop_process(self, name: str, timeout: int = 2):
+        if not (proc := self.processes.get(name)):
             return True
 
-        try:
-            process.terminate()
-            process.wait(timeout=timeout)
-        except subprocess.TimeoutExpired:
-            process.kill()
-            process.wait(timeout=1)
-        except Exception:
-            pass
+        with suppress(Exception):
+            proc.terminate()
+            try:
+                proc.wait(timeout=timeout)
+            except subprocess.TimeoutExpired:
+                proc.kill()
+                proc.wait(timeout=1)
 
         self.processes.pop(name, None)
         return True
 
-    def stop_all(self, timeout: int = 2) -> None:
-        if self.shutdown_event.is_set():
+    def stop_all(self, timeout: int = 2):
+        if self.shutdown.is_set():
             return
 
-        self.shutdown_event.set()
+        self.shutdown.set()
+
         for name in list(self.processes):
             self.stop_process(name, timeout)
 
         self.processes.clear()
         self.threads.clear()
 
-    def wait_for_any_exit(self) -> None:
-        while not self.shutdown_event.is_set():
-            dead_processes = [
-                name
-                for name, proc in self.processes.items()
+    def wait_for_any_exit(self):
+        while not self.shutdown.is_set():
+            dead = [
+                name for name, proc in self.processes.items()
                 if proc.poll() is not None
+                # Tailwind exiting cleanly is expected
                 and not (name == "tailwind" and proc.returncode == 0)
             ]
 
-            if dead_processes:
-                for name in dead_processes:
+            if dead:
+                for name in dead:
                     self.console.print(f"[red]{name} died unexpectedly[/red]")
                     del self.processes[name]
 
-                if "uvicorn" in dead_processes:
+                if "uvicorn" in dead:
                     break
 
             time.sleep(0.5)

--- a/tests/cli/test_dev.py
+++ b/tests/cli/test_dev.py
@@ -1,7 +1,5 @@
 """Tests for the development server command."""
 
-import subprocess
-import time
 from pathlib import Path
 from unittest.mock import MagicMock, patch
 
@@ -10,8 +8,6 @@ import pytest
 from starui.cli.dev import (
     cleanup,
     get_or_create_css_input,
-    setup_tailwind,
-    show_status,
     wait_for_css,
 )
 from starui.dev.process_manager import ProcessManager
@@ -21,13 +17,13 @@ def test_get_or_create_css_input_existing(tmp_path):
     """Test that existing input.css is returned."""
     config = MagicMock()
     config.project_root = tmp_path
-    
+
     # Create existing input.css
     css_dir = tmp_path / "static" / "css"
     css_dir.mkdir(parents=True)
     input_css = css_dir / "input.css"
     input_css.write_text("/* existing */")
-    
+
     result = get_or_create_css_input(config)
     assert result == input_css
 
@@ -37,11 +33,11 @@ def test_get_or_create_css_input_creates_temp(tmp_path):
     config = MagicMock()
     config.project_root = tmp_path
     config.css_output_absolute = tmp_path / "output.css"
-    
+
     with patch("starui.cli.dev.generate_css_input") as mock_gen:
         mock_gen.return_value = "/* generated */"
         result = get_or_create_css_input(config)
-        
+
         assert result.exists()
         assert result.suffix == ".css"
         assert result.read_text() == "/* generated */"
@@ -52,9 +48,9 @@ def test_cleanup():
     """Test cleanup removes files."""
     mock_paths = [MagicMock(spec=Path) for _ in range(3)]
     mock_paths.append(None)  # Test None handling
-    
+
     cleanup(*mock_paths)
-    
+
     for path in mock_paths[:3]:
         path.unlink.assert_called_once_with(missing_ok=True)
 
@@ -64,7 +60,7 @@ def test_wait_for_css_exists(mock_success, tmp_path):
     """Test wait_for_css when CSS already exists."""
     css_path = tmp_path / "test.css"
     css_path.write_text("/* css */")
-    
+
     wait_for_css(css_path)
     mock_success.assert_called_once_with("CSS ready")
 
@@ -76,33 +72,33 @@ def test_wait_for_css_timeout(mock_sleep, mock_console, mock_error, tmp_path):
     """Test wait_for_css timeout."""
     from click.exceptions import Exit
     css_path = tmp_path / "nonexistent.css"
-    
+
     with pytest.raises(Exit):
         wait_for_css(css_path, timeout=0.1)
-    
+
     mock_console.print.assert_called_once()
     mock_error.assert_called_once_with("CSS build timed out")
 
 
 class TestProcessManager:
     """Tests for ProcessManager class."""
-    
+
     def test_init(self):
         """Test ProcessManager initialization."""
         manager = ProcessManager()
         assert manager.processes == {}
         assert manager.threads == {}
         assert not manager.shutdown.is_set()
-    
+
     def test_start_process_existing(self):
         """Test starting process when one already exists."""
         manager = ProcessManager()
         mock_process = MagicMock()
         manager.processes["test"] = mock_process
-        
+
         result = manager.start_process("test", ["cmd"])
         assert result == mock_process
-    
+
     @patch("subprocess.Popen")
     def test_start_process_new(self, mock_popen):
         """Test starting a new process."""
@@ -111,44 +107,44 @@ class TestProcessManager:
         mock_proc.stdout.readline.return_value = ""
         mock_proc.poll.return_value = 0
         mock_popen.return_value = mock_proc
-        
+
         result = manager.start_process("test", ["cmd"])
         assert result == mock_proc
         assert manager.processes["test"] == mock_proc
-    
+
     def test_is_running(self):
         """Test checking if process is running."""
         manager = ProcessManager()
         mock_proc = MagicMock()
         mock_proc.poll.return_value = None
         manager.processes["test"] = mock_proc
-        
+
         assert manager.is_running("test")
-        
+
         mock_proc.poll.return_value = 0
         assert not manager.is_running("test")
-    
+
     def test_stop_process(self):
         """Test stopping a process."""
         manager = ProcessManager()
         mock_proc = MagicMock()
         manager.processes["test"] = mock_proc
-        
+
         manager.stop_process("test")
         mock_proc.terminate.assert_called_once()
         assert "test" not in manager.processes
-    
+
     def test_stop_all(self):
         """Test stopping all processes."""
         manager = ProcessManager()
         mock_procs = {f"test{i}": MagicMock() for i in range(3)}
         manager.processes = mock_procs.copy()
-        
+
         manager.stop_all()
-        
+
         assert manager.shutdown.is_set()
         assert manager.processes == {}
         assert manager.threads == {}
-        
+
         for proc in mock_procs.values():
             proc.terminate.assert_called_once()

--- a/tests/cli/test_dev.py
+++ b/tests/cli/test_dev.py
@@ -71,6 +71,7 @@ def test_wait_for_css_exists(mock_success, tmp_path):
 def test_wait_for_css_timeout(mock_sleep, mock_console, mock_error, tmp_path):
     """Test wait_for_css timeout."""
     from click.exceptions import Exit
+
     css_path = tmp_path / "nonexistent.css"
 
     with pytest.raises(Exit):

--- a/tests/cli/test_dev.py
+++ b/tests/cli/test_dev.py
@@ -1,0 +1,154 @@
+"""Tests for the development server command."""
+
+import subprocess
+import time
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from starui.cli.dev import (
+    cleanup,
+    get_or_create_css_input,
+    setup_tailwind,
+    show_status,
+    wait_for_css,
+)
+from starui.dev.process_manager import ProcessManager
+
+
+def test_get_or_create_css_input_existing(tmp_path):
+    """Test that existing input.css is returned."""
+    config = MagicMock()
+    config.project_root = tmp_path
+    
+    # Create existing input.css
+    css_dir = tmp_path / "static" / "css"
+    css_dir.mkdir(parents=True)
+    input_css = css_dir / "input.css"
+    input_css.write_text("/* existing */")
+    
+    result = get_or_create_css_input(config)
+    assert result == input_css
+
+
+def test_get_or_create_css_input_creates_temp(tmp_path):
+    """Test that temporary CSS is created when no input.css exists."""
+    config = MagicMock()
+    config.project_root = tmp_path
+    config.css_output_absolute = tmp_path / "output.css"
+    
+    with patch("starui.cli.dev.generate_css_input") as mock_gen:
+        mock_gen.return_value = "/* generated */"
+        result = get_or_create_css_input(config)
+        
+        assert result.exists()
+        assert result.suffix == ".css"
+        assert result.read_text() == "/* generated */"
+        mock_gen.assert_called_once_with(config)
+
+
+def test_cleanup():
+    """Test cleanup removes files."""
+    mock_paths = [MagicMock(spec=Path) for _ in range(3)]
+    mock_paths.append(None)  # Test None handling
+    
+    cleanup(*mock_paths)
+    
+    for path in mock_paths[:3]:
+        path.unlink.assert_called_once_with(missing_ok=True)
+
+
+@patch("starui.cli.dev.success")
+def test_wait_for_css_exists(mock_success, tmp_path):
+    """Test wait_for_css when CSS already exists."""
+    css_path = tmp_path / "test.css"
+    css_path.write_text("/* css */")
+    
+    wait_for_css(css_path)
+    mock_success.assert_called_once_with("CSS ready")
+
+
+@patch("starui.cli.dev.error")
+@patch("starui.cli.dev.console")
+@patch("time.sleep")
+def test_wait_for_css_timeout(mock_sleep, mock_console, mock_error, tmp_path):
+    """Test wait_for_css timeout."""
+    from click.exceptions import Exit
+    css_path = tmp_path / "nonexistent.css"
+    
+    with pytest.raises(Exit):
+        wait_for_css(css_path, timeout=0.1)
+    
+    mock_console.print.assert_called_once()
+    mock_error.assert_called_once_with("CSS build timed out")
+
+
+class TestProcessManager:
+    """Tests for ProcessManager class."""
+    
+    def test_init(self):
+        """Test ProcessManager initialization."""
+        manager = ProcessManager()
+        assert manager.processes == {}
+        assert manager.threads == {}
+        assert not manager.shutdown.is_set()
+    
+    def test_start_process_existing(self):
+        """Test starting process when one already exists."""
+        manager = ProcessManager()
+        mock_process = MagicMock()
+        manager.processes["test"] = mock_process
+        
+        result = manager.start_process("test", ["cmd"])
+        assert result == mock_process
+    
+    @patch("subprocess.Popen")
+    def test_start_process_new(self, mock_popen):
+        """Test starting a new process."""
+        manager = ProcessManager()
+        mock_proc = MagicMock()
+        mock_proc.stdout.readline.return_value = ""
+        mock_proc.poll.return_value = 0
+        mock_popen.return_value = mock_proc
+        
+        result = manager.start_process("test", ["cmd"])
+        assert result == mock_proc
+        assert manager.processes["test"] == mock_proc
+    
+    def test_is_running(self):
+        """Test checking if process is running."""
+        manager = ProcessManager()
+        mock_proc = MagicMock()
+        mock_proc.poll.return_value = None
+        manager.processes["test"] = mock_proc
+        
+        assert manager.is_running("test")
+        
+        mock_proc.poll.return_value = 0
+        assert not manager.is_running("test")
+    
+    def test_stop_process(self):
+        """Test stopping a process."""
+        manager = ProcessManager()
+        mock_proc = MagicMock()
+        manager.processes["test"] = mock_proc
+        
+        manager.stop_process("test")
+        mock_proc.terminate.assert_called_once()
+        assert "test" not in manager.processes
+    
+    def test_stop_all(self):
+        """Test stopping all processes."""
+        manager = ProcessManager()
+        mock_procs = {f"test{i}": MagicMock() for i in range(3)}
+        manager.processes = mock_procs.copy()
+        
+        manager.stop_all()
+        
+        assert manager.shutdown.is_set()
+        assert manager.processes == {}
+        assert manager.threads == {}
+        
+        for proc in mock_procs.values():
+            proc.terminate.assert_called_once()


### PR DESCRIPTION
## Summary
- Fixed warning: "Could not replace dev reload system: property 'routes' has no setter"
- Cleaned up terminal output with proper formatting and line breaks
- Updated to starhtml 0.1.15 for compatibility

## Changes
- **Fixed live reload integration**: Now properly handles StarHTML's new structure by accessing router and filtering routes instead of trying to set read-only properties
- **Improved terminal output**: Removed duplicate messages, fixed line breaks, and cleaned up formatting
- **Code quality improvements**: Refactored both dev.py and process_manager.py to be more idiomatic and concise (~25% reduction in code)
- **Added tests**: Comprehensive test coverage for dev command and ProcessManager

## Test Plan
- [x] Manual testing with `uv run star dev app.py`
- [x] WebSocket hot reload verified working
- [x] CSS hot reload verified working
- [x] All quality checks pass (ruff, pyright)
- [x] New tests added and passing

## Before/After

**Before:**
```
Warning: Could not replace dev reload system: property 'routes'...
Starting tailwind...
Starting tailwind...
✓ ✓ CSS built
```

**After:**
```
Starting tailwind...
✓ CSS ready
Starting uvicorn...
✓ Server running at http://localhost:5000
[StarUI] ✓ Replaced StarHTML live reload with unified dev reload system
```