### PR TITLE
Fix JavaScript rendering as text on page

### DIFF
--- a/src/starui/dev/unified_reload.py
+++ b/src/starui/dev/unified_reload.py
@@ -89,10 +89,11 @@ def create_dev_reload_route() -> WebSocketRoute:
     return WebSocketRoute("/live-reload", endpoint=DevReloadHandler)
 
 
-def DevReloadJs(**kwargs) -> str:
+def DevReloadJs(**kwargs):
     """Generate unified development reload JavaScript."""
-    return """<script>
-(() => {
+    from starhtml.xtend import Script
+    
+    js_code = """(() => {
     if (!['localhost', '127.0.0.1'].includes(location.hostname)) return;
 
     let attempts = 0;
@@ -164,5 +165,6 @@ def DevReloadJs(**kwargs) -> str:
     };
 
     connect();
-})();
-</script>"""
+})();"""
+    
+    return Script(js_code)

--- a/src/starui/dev/unified_reload.py
+++ b/src/starui/dev/unified_reload.py
@@ -92,7 +92,7 @@ def create_dev_reload_route() -> WebSocketRoute:
 def DevReloadJs(**kwargs):
     """Generate unified development reload JavaScript."""
     from starhtml.xtend import Script
-    
+
     js_code = """(() => {
     if (!['localhost', '127.0.0.1'].includes(location.hostname)) return;
 
@@ -166,5 +166,5 @@ def DevReloadJs(**kwargs):
 
     connect();
 })();"""
-    
+
     return Script(js_code)


### PR DESCRIPTION
## Problem
After merging PR #22, the development reload JavaScript was being displayed as text on the page instead of being executed.

## Root Cause
The `DevReloadJs` function was returning a raw string with `<script>` tags, but StarHTML expects a proper Script element object.

## Solution
Modified `DevReloadJs` to:
- Import `Script` from `starhtml.xtend`
- Return a proper `Script` element instead of a raw string
- This ensures the JavaScript is properly rendered in the HTML head

## Testing
- Tested locally with `uv run star dev app.py`
- Verified JavaScript no longer appears as text on the page
- WebSocket hot reload connection works correctly