### PR TITLE
fix: remove incorrect Tailwind v4 config and fix wrapper import

### DIFF
--- a/src/starui/cli/dev.py
+++ b/src/starui/cli/dev.py
@@ -132,8 +132,9 @@ def dev_command(
             debug,
         )
 
-        # Collect wrapper files for cleanup
-        temp_files.extend(app_path.parent.glob(f"{app_path.stem}_dev*.py"))
+        # Collect wrapper files for cleanup (now in temp dir)
+        temp_dir = Path(tempfile.gettempdir())
+        temp_files.extend(temp_dir.glob(f"starui_dev_{app_path.stem}_*.py"))
         temp_files.extend(config.css_output_absolute.parent.glob("tmp*.css"))
 
         success(f"Server running at http://localhost:{app_port}")

--- a/src/starui/dev/process_manager.py
+++ b/src/starui/dev/process_manager.py
@@ -8,105 +8,21 @@ import time
 from collections.abc import Callable
 from contextlib import suppress
 from pathlib import Path
+from tempfile import gettempdir
+from typing import Any
 
 from rich.console import Console
 
 RELOAD_EXCLUDES = ["*.css", "static/**", "**/tmp*", "**/__pycache__/**", "*_dev.py"]
+RENDER_PROCESSES = {"uvicorn", "tailwind"}
 
+WRAPPER_TEMPLATE = """import sys
+import warnings
+sys.path.insert(0, r'{app_dir}')
 
-class ProcessManager:
-    def __init__(self):
-        self.processes = {}
-        self.threads = {}
-        self.shutdown = threading.Event()
-        self.console = Console()
+warnings.filterwarnings('ignore', message='live=True requires debug=True.*', category=UserWarning)
 
-    def start_process(
-        self, name: str, cmd: list[str], cwd: Path = None, env: dict = None
-    ):
-        if existing := self.processes.get(name):
-            self.console.print(f"[yellow]{name} already running[/yellow]")
-            return existing
-
-        # Set COLUMNS to prevent line wrapping in subprocess output
-        if env is None:
-            env = os.environ.copy()
-        if "COLUMNS" not in env:
-            env["COLUMNS"] = "200"
-
-        proc = subprocess.Popen(
-            cmd,
-            cwd=cwd,
-            env=env,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            text=True,
-            bufsize=1,
-        )
-        self.processes[name] = proc
-        self._monitor(name, proc)
-        return proc
-
-    def _monitor(self, name: str, proc: subprocess.Popen):
-        def run():
-            with suppress(Exception):
-                while proc.poll() is None and not self.shutdown.is_set():
-                    if line := proc.stdout.readline():
-                        if clean := line.rstrip():
-                            # Let uvicorn/tailwind format their own output
-                            if name in ("uvicorn", "tailwind"):
-                                # Use direct print to preserve original formatting
-                                print(clean, flush=True)
-                            else:
-                                self.console.print(
-                                    f"[dim cyan][{name}][/dim cyan] {clean}"
-                                )
-                    else:
-                        time.sleep(0.1)
-
-        thread = threading.Thread(target=run, daemon=True)
-        thread.start()
-        self.threads[f"{name}_monitor"] = thread
-
-    def start_uvicorn(
-        self,
-        app_file: Path,
-        port: int,
-        patterns: list[str],
-        hot_reload: bool = True,
-        debug: bool = True,
-    ):
-        module = self._get_app_module(app_file, hot_reload, debug)
-        cmd = [
-            sys.executable,
-            "-m",
-            "uvicorn",
-            module,
-            "--reload",
-            "--port",
-            str(port),
-            "--host",
-            "localhost",
-            "--reload-delay",
-            "0.1",
-        ]
-
-        for pattern in patterns:
-            cmd.extend(["--reload-include", pattern])
-        for exclude in RELOAD_EXCLUDES:
-            cmd.extend(["--reload-exclude", exclude])
-
-        env = os.environ.copy()
-        env["COLUMNS"] = "200"  # Prevent line wrapping in output
-        return self.start_process("uvicorn", cmd, app_file.parent, env)
-
-    def _get_app_module(self, app_file: Path, hot_reload: bool, debug: bool):
-        if not hot_reload:
-            return f"{app_file.stem}:app"
-
-        wrapper = app_file.parent / f"{app_file.stem}_dev.py"
-        wrapper.write_text(f"""import sys
-from {app_file.stem} import app as original_app
+from {app_stem} import app as original_app
 from starui.dev.unified_reload import create_dev_reload_route, DevReloadJs
 from starlette.routing import WebSocketRoute
 
@@ -149,7 +65,111 @@ except Exception as e:
     sys.stderr.write(f"[StarUI] Warning: Could not fully replace dev reload system: {{e}}\\n")
     sys.stderr.flush()
 
-app = original_app""")
+app = original_app"""
+
+
+class ProcessManager:
+    def __init__(self):
+        self.processes = {}
+        self.threads = {}
+        self.shutdown = threading.Event()
+        self.console = Console()
+
+    def start_process(
+        self,
+        name: str,
+        cmd: list[str],
+        cwd: Path | None = None,
+        env: dict[str, Any] | None = None,
+    ) -> subprocess.Popen[str]:
+        if existing := self.processes.get(name):
+            self.console.print(f"[yellow]{name} already running[/yellow]")
+            return existing
+
+        proc = subprocess.Popen(
+            cmd,
+            cwd=cwd,
+            env=env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            bufsize=1,
+        )
+        self.processes[name] = proc
+        self._monitor(name, proc)
+        return proc
+
+    def _monitor(self, name: str, proc: subprocess.Popen[str]) -> None:
+        def run() -> None:
+            with suppress(Exception):
+                while proc.poll() is None and not self.shutdown.is_set():
+                    if line := proc.stdout.readline():
+                        if clean := line.rstrip():
+                            if name in RENDER_PROCESSES:
+                                sys.stdout.write(f"{clean}\n")
+                                sys.stdout.flush()
+                            else:
+                                self.console.print(
+                                    f"[dim cyan][{name}][/dim cyan] {clean}"
+                                )
+                    else:
+                        time.sleep(0.1)
+
+        thread = threading.Thread(target=run, daemon=True)
+        thread.start()
+        self.threads[f"{name}_monitor"] = thread
+
+    def start_uvicorn(
+        self,
+        app_file: Path,
+        port: int,
+        patterns: list[str],
+        hot_reload: bool = True,
+        debug: bool = True,
+    ) -> subprocess.Popen[str]:
+        module = self._get_app_module(app_file, hot_reload, debug)
+        cmd = [
+            sys.executable,
+            "-m",
+            "uvicorn",
+            module,
+            "--reload",
+            "--port",
+            str(port),
+            "--host",
+            "localhost",
+            "--reload-delay",
+            "0.1",
+            "--use-colors",
+        ]
+
+        for pattern in patterns:
+            cmd.extend(["--reload-include", pattern])
+        for exclude in RELOAD_EXCLUDES:
+            cmd.extend(["--reload-exclude", exclude])
+
+        env = os.environ.copy()
+        if hot_reload:
+            temp_dir = Path(gettempdir())
+            pythonpath = env.get("PYTHONPATH", "")
+            env["PYTHONPATH"] = (
+                f"{temp_dir}:{pythonpath}" if pythonpath else str(temp_dir)
+            )
+
+        return self.start_process("uvicorn", cmd, app_file.parent, env)
+
+    def _get_app_module(self, app_file: Path, hot_reload: bool, debug: bool) -> str:
+        if not hot_reload:
+            return f"{app_file.stem}:app"
+
+        temp_dir = Path(gettempdir())
+        wrapper = temp_dir / f"starui_dev_{app_file.stem}_{os.getpid()}.py"
+
+        wrapper.write_text(
+            WRAPPER_TEMPLATE.format(
+                app_dir=app_file.parent, app_stem=app_file.stem, debug=debug
+            )
+        )
         return f"{wrapper.stem}:app"
 
     def start_tailwind_watcher(
@@ -158,8 +178,8 @@ app = original_app""")
         input_css: Path,
         output_css: Path,
         project_root: Path,
-        on_rebuild: Callable = None,
-    ):
+        on_rebuild: Callable[[Path], None] | None = None,
+    ) -> subprocess.Popen[str]:
         cmd = [
             str(binary),
             "--input",
@@ -170,18 +190,17 @@ app = original_app""")
             "--cwd",
             str(project_root),
         ]
-        proc = self.start_process("tailwind", cmd, project_root)
 
+        proc = self.start_process("tailwind", cmd, project_root)
         if on_rebuild:
             self._watch(output_css, on_rebuild)
-
         return proc
 
-    def _watch(self, path: Path, callback: Callable):
-        def run():
+    def _watch(self, path: Path, callback: Callable[[Path], None]) -> None:
+        def run() -> None:
             last = path.stat().st_mtime if path.exists() else 0
             if last:
-                callback(path)  # Initial trigger
+                callback(path)
 
             while not self.shutdown.is_set():
                 with suppress(Exception):
@@ -197,7 +216,7 @@ app = original_app""")
     def is_running(self, name: str) -> bool:
         return (p := self.processes.get(name)) and p.poll() is None
 
-    def stop_process(self, name: str, timeout: int = 2):
+    def stop_process(self, name: str, timeout: int = 2) -> bool:
         if not (proc := self.processes.get(name)):
             return True
 
@@ -212,25 +231,23 @@ app = original_app""")
         self.processes.pop(name, None)
         return True
 
-    def stop_all(self, timeout: int = 2):
+    def stop_all(self, timeout: int = 2) -> None:
         if self.shutdown.is_set():
             return
 
         self.shutdown.set()
-
         for name in list(self.processes):
             self.stop_process(name, timeout)
 
         self.processes.clear()
         self.threads.clear()
 
-    def wait_for_any_exit(self):
+    def wait_for_any_exit(self) -> None:
         while not self.shutdown.is_set():
             dead = [
                 name
                 for name, proc in self.processes.items()
                 if proc.poll() is not None
-                # Tailwind exiting cleanly is expected
                 and not (name == "tailwind" and proc.returncode == 0)
             ]
 


### PR DESCRIPTION
## Summary
- Remove tailwind.config.js creation/copying logic (not used in Tailwind v4)
- Fix TypeError by removing leading dot from wrapper filename  
- Suppress verbose StarHTML warnings about live=True
- Add PYTHONPATH for temp wrapper module access

## Test plan
- [x] Run `uv run star dev app.py` - no more TypeError
- [x] Verify warning about live=True is suppressed
- [x] Confirm dev server starts correctly
- [x] Pass ruff check and format