### PR TITLE
feat: add Table component with ShadCN styling

### DIFF
--- a/src/starui/registry/component_metadata.py
+++ b/src/starui/registry/component_metadata.py
@@ -89,6 +89,7 @@ COMPONENT_REGISTRY = {
         ["utils"],
         css_imports=['@plugin "@tailwindcss/typography";'],
     ),
+    "table": _component("table", "Data display in rows and columns", ["utils"]),
     "utils": _component("utils", "Class name utilities"),
 }
 

--- a/src/starui/registry/components/table.py
+++ b/src/starui/registry/components/table.py
@@ -1,0 +1,170 @@
+from typing import Any
+
+from starhtml import (
+    FT,
+    Caption,
+    Div,
+    Table as HTMLTable,
+    Tbody,
+    Td,
+    Tfoot,
+    Th,
+    Thead,
+    Tr,
+)
+
+from .utils import cn
+
+
+def Table(
+    *children: Any,
+    class_name: str = "",
+    cls: str = "",
+    **attrs: Any,
+) -> FT:
+    """Table container with overflow handling and proper border styling."""
+    classes = cn("w-full caption-bottom text-sm", class_name, cls)
+    
+    return Div(
+        HTMLTable(
+            *children,
+            data_slot="table",
+            cls=classes,
+            **attrs
+        ),
+        data_slot="table-container",
+        cls="relative w-full overflow-x-auto"
+    )
+
+
+def TableHeader(
+    *children: Any,
+    class_name: str = "",
+    cls: str = "",
+    **attrs: Any,
+) -> FT:
+    """Table header with border styling."""
+    classes = cn("[&_tr]:border-b", class_name, cls)
+    return Thead(
+        *children,
+        data_slot="table-header",
+        cls=classes,
+        **attrs
+    )
+
+
+def TableBody(
+    *children: Any,
+    class_name: str = "",
+    cls: str = "",
+    **attrs: Any,
+) -> FT:
+    """Table body with last row border handling."""
+    classes = cn("[&_tr:last-child]:border-0", class_name, cls)
+    return Tbody(
+        *children,
+        data_slot="table-body",
+        cls=classes,
+        **attrs
+    )
+
+
+def TableFooter(
+    *children: Any,
+    class_name: str = "",
+    cls: str = "",
+    **attrs: Any,
+) -> FT:
+    """Table footer with background and border styling."""
+    classes = cn(
+        "bg-muted/50 border-t font-medium [&>tr]:last:border-b-0",
+        class_name,
+        cls
+    )
+    return Tfoot(
+        *children,
+        data_slot="table-footer",
+        cls=classes,
+        **attrs
+    )
+
+
+def TableRow(
+    *children: Any,
+    selected: bool = False,
+    class_name: str = "",
+    cls: str = "",
+    **attrs: Any,
+) -> FT:
+    """Table row with hover and selection states."""
+    classes = cn(
+        "border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted",
+        class_name,
+        cls
+    )
+    
+    if selected:
+        attrs["data_state"] = "selected"
+    
+    return Tr(
+        *children,
+        data_slot="table-row",
+        cls=classes,
+        **attrs
+    )
+
+
+def TableHead(
+    *children: Any,
+    class_name: str = "",
+    cls: str = "",
+    **attrs: Any,
+) -> FT:
+    """Table header cell with proper padding and font styling."""
+    classes = cn(
+        "text-foreground h-10 px-2 text-left align-middle font-medium whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+        class_name,
+        cls
+    )
+    return Th(
+        *children,
+        data_slot="table-head",
+        cls=classes,
+        **attrs
+    )
+
+
+def TableCell(
+    *children: Any,
+    class_name: str = "",
+    cls: str = "",
+    **attrs: Any,
+) -> FT:
+    """Table cell with proper styling and text size."""
+    classes = cn(
+        "p-2 align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
+        class_name,
+        cls
+    )
+    return Td(
+        *children,
+        data_slot="table-cell",
+        cls=classes,
+        **attrs
+    )
+
+
+def TableCaption(
+    *children: Any,
+    class_name: str = "",
+    cls: str = "",
+    **attrs: Any,
+) -> FT:
+    """Table caption with muted text styling."""
+    classes = cn("mt-4 text-sm text-muted-foreground", class_name, cls)
+    return Caption(
+        *children,
+        data_slot="table-caption",
+        cls=classes,
+        **attrs
+    )

--- a/src/starui/registry/components/table.py
+++ b/src/starui/registry/components/table.py
@@ -4,13 +4,15 @@ from starhtml import (
     FT,
     Caption,
     Div,
-    Table as HTMLTable,
     Tbody,
     Td,
     Tfoot,
     Th,
     Thead,
     Tr,
+)
+from starhtml import (
+    Table as HTMLTable,
 )
 
 from .utils import cn
@@ -22,9 +24,7 @@ def Table(
     cls: str = "",
     **attrs: Any,
 ) -> FT:
-    """Table container with overflow handling and proper border styling."""
     classes = cn("w-full caption-bottom text-sm", class_name, cls)
-    
     return Div(
         HTMLTable(
             *children,
@@ -43,8 +43,7 @@ def TableHeader(
     cls: str = "",
     **attrs: Any,
 ) -> FT:
-    """Table header with border styling."""
-    classes = cn("[&_tr]:border-b", class_name, cls)
+    classes = cn("[&_tr]:border-b [&_tr]:border-input", class_name, cls)
     return Thead(
         *children,
         data_slot="table-header",
@@ -59,7 +58,6 @@ def TableBody(
     cls: str = "",
     **attrs: Any,
 ) -> FT:
-    """Table body with last row border handling."""
     classes = cn("[&_tr:last-child]:border-0", class_name, cls)
     return Tbody(
         *children,
@@ -75,9 +73,8 @@ def TableFooter(
     cls: str = "",
     **attrs: Any,
 ) -> FT:
-    """Table footer with background and border styling."""
     classes = cn(
-        "bg-muted/50 border-t font-medium [&>tr]:last:border-b-0",
+        "bg-muted/50 border-t border-input font-medium [&>tr]:last:border-b-0",
         class_name,
         cls
     )
@@ -96,16 +93,15 @@ def TableRow(
     cls: str = "",
     **attrs: Any,
 ) -> FT:
-    """Table row with hover and selection states."""
     classes = cn(
-        "border-b transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted",
+        "border-b border-input transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted",
         class_name,
         cls
     )
-    
+
     if selected:
         attrs["data_state"] = "selected"
-    
+
     return Tr(
         *children,
         data_slot="table-row",
@@ -120,7 +116,6 @@ def TableHead(
     cls: str = "",
     **attrs: Any,
 ) -> FT:
-    """Table header cell with proper padding and font styling."""
     classes = cn(
         "text-foreground h-10 px-2 text-left align-middle font-medium whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
         class_name,
@@ -140,7 +135,6 @@ def TableCell(
     cls: str = "",
     **attrs: Any,
 ) -> FT:
-    """Table cell with proper styling and text size."""
     classes = cn(
         "p-2 align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
         class_name,
@@ -160,7 +154,6 @@ def TableCaption(
     cls: str = "",
     **attrs: Any,
 ) -> FT:
-    """Table caption with muted text styling."""
     classes = cn("mt-4 text-sm text-muted-foreground", class_name, cls)
     return Caption(
         *children,

--- a/src/starui/registry/components/table.py
+++ b/src/starui/registry/components/table.py
@@ -26,14 +26,9 @@ def Table(
 ) -> FT:
     classes = cn("w-full caption-bottom text-sm", class_name, cls)
     return Div(
-        HTMLTable(
-            *children,
-            data_slot="table",
-            cls=classes,
-            **attrs
-        ),
+        HTMLTable(*children, data_slot="table", cls=classes, **attrs),
         data_slot="table-container",
-        cls="relative w-full overflow-x-auto"
+        cls="relative w-full overflow-x-auto",
     )
 
 
@@ -44,12 +39,7 @@ def TableHeader(
     **attrs: Any,
 ) -> FT:
     classes = cn("[&_tr]:border-b [&_tr]:border-input", class_name, cls)
-    return Thead(
-        *children,
-        data_slot="table-header",
-        cls=classes,
-        **attrs
-    )
+    return Thead(*children, data_slot="table-header", cls=classes, **attrs)
 
 
 def TableBody(
@@ -59,12 +49,7 @@ def TableBody(
     **attrs: Any,
 ) -> FT:
     classes = cn("[&_tr:last-child]:border-0", class_name, cls)
-    return Tbody(
-        *children,
-        data_slot="table-body",
-        cls=classes,
-        **attrs
-    )
+    return Tbody(*children, data_slot="table-body", cls=classes, **attrs)
 
 
 def TableFooter(
@@ -76,14 +61,9 @@ def TableFooter(
     classes = cn(
         "bg-muted/50 border-t border-input font-medium [&>tr]:last:border-b-0",
         class_name,
-        cls
+        cls,
     )
-    return Tfoot(
-        *children,
-        data_slot="table-footer",
-        cls=classes,
-        **attrs
-    )
+    return Tfoot(*children, data_slot="table-footer", cls=classes, **attrs)
 
 
 def TableRow(
@@ -96,18 +76,13 @@ def TableRow(
     classes = cn(
         "border-b border-input transition-colors hover:bg-muted/50 data-[state=selected]:bg-muted",
         class_name,
-        cls
+        cls,
     )
 
     if selected:
         attrs["data_state"] = "selected"
 
-    return Tr(
-        *children,
-        data_slot="table-row",
-        cls=classes,
-        **attrs
-    )
+    return Tr(*children, data_slot="table-row", cls=classes, **attrs)
 
 
 def TableHead(
@@ -119,14 +94,9 @@ def TableHead(
     classes = cn(
         "text-foreground h-10 px-2 text-left align-middle font-medium whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
         class_name,
-        cls
+        cls,
     )
-    return Th(
-        *children,
-        data_slot="table-head",
-        cls=classes,
-        **attrs
-    )
+    return Th(*children, data_slot="table-head", cls=classes, **attrs)
 
 
 def TableCell(
@@ -138,14 +108,9 @@ def TableCell(
     classes = cn(
         "p-2 align-middle whitespace-nowrap [&:has([role=checkbox])]:pr-0 [&>[role=checkbox]]:translate-y-[2px]",
         class_name,
-        cls
+        cls,
     )
-    return Td(
-        *children,
-        data_slot="table-cell",
-        cls=classes,
-        **attrs
-    )
+    return Td(*children, data_slot="table-cell", cls=classes, **attrs)
 
 
 def TableCaption(
@@ -155,9 +120,4 @@ def TableCaption(
     **attrs: Any,
 ) -> FT:
     classes = cn("mt-4 text-sm text-muted-foreground", class_name, cls)
-    return Caption(
-        *children,
-        data_slot="table-caption",
-        cls=classes,
-        **attrs
-    )
+    return Caption(*children, data_slot="table-caption", cls=classes, **attrs)

--- a/test_sandbox/app.py
+++ b/test_sandbox/app.py
@@ -1408,6 +1408,148 @@ def index():
                     cls="p-4 border rounded-lg mb-8",
                 ),
             ),
+            # Table examples
+            Div(
+                H2("Tables", cls="text-2xl font-semibold mb-4"),
+                Div(
+                    # Basic table
+                    Div(
+                        H3("Basic Table", cls="text-lg font-medium mb-2"),
+                        Table(
+                            TableHeader(
+                                TableRow(
+                                    TableHead("Invoice"),
+                                    TableHead("Status"),
+                                    TableHead("Method"),
+                                    TableHead("Amount", cls="text-right"),
+                                )
+                            ),
+                            TableBody(
+                                TableRow(
+                                    TableCell("INV001"),
+                                    TableCell(Badge("Paid", variant="secondary")),
+                                    TableCell("Credit Card"),
+                                    TableCell("$250.00", cls="text-right"),
+                                ),
+                                TableRow(
+                                    TableCell("INV002"),
+                                    TableCell(Badge("Pending", variant="outline")),
+                                    TableCell("PayPal"),
+                                    TableCell("$150.00", cls="text-right"),
+                                ),
+                                TableRow(
+                                    TableCell("INV003"),
+                                    TableCell(Badge("Unpaid", variant="destructive")),
+                                    TableCell("Bank Transfer"),
+                                    TableCell("$350.00", cls="text-right"),
+                                ),
+                                TableRow(
+                                    TableCell("INV004"),
+                                    TableCell(Badge("Paid", variant="secondary")),
+                                    TableCell("Credit Card"),
+                                    TableCell("$450.00", cls="text-right"),
+                                ),
+                            ),
+                            TableFooter(
+                                TableRow(
+                                    TableCell("Total", colspan="3", cls="font-medium"),
+                                    TableCell("$1,200.00", cls="text-right font-medium"),
+                                )
+                            ),
+                            cls="mb-6",
+                        ),
+                        cls="mb-8",
+                    ),
+                    # Table with selection
+                    Div(
+                        H3("Table with Selection", cls="text-lg font-medium mb-2"),
+                        Table(
+                            TableCaption("A list of users with selection capabilities."),
+                            TableHeader(
+                                TableRow(
+                                    TableHead("Select"),
+                                    TableHead("Name"),
+                                    TableHead("Email"),
+                                    TableHead("Role"),
+                                    TableHead("Actions"),
+                                )
+                            ),
+                            TableBody(
+                                TableRow(
+                                    TableCell(Checkbox(signal="user_1")),
+                                    TableCell("John Doe"),
+                                    TableCell("john@example.com"),
+                                    TableCell(Badge("Admin")),
+                                    TableCell(
+                                        Button("Edit", variant="ghost", size="sm"),
+                                        cls="space-x-2",
+                                    ),
+                                ),
+                                TableRow(
+                                    TableCell(Checkbox(signal="user_2", checked=True)),
+                                    TableCell("Jane Smith"),
+                                    TableCell("jane@example.com"),
+                                    TableCell(Badge("User", variant="secondary")),
+                                    TableCell(
+                                        Button("Edit", variant="ghost", size="sm"),
+                                        cls="space-x-2",
+                                    ),
+                                    selected=True,
+                                ),
+                                TableRow(
+                                    TableCell(Checkbox(signal="user_3")),
+                                    TableCell("Bob Johnson"),
+                                    TableCell("bob@example.com"),
+                                    TableCell(Badge("User", variant="secondary")),
+                                    TableCell(
+                                        Button("Edit", variant="ghost", size="sm"),
+                                        cls="space-x-2",
+                                    ),
+                                ),
+                            ),
+                            cls="mb-6",
+                        ),
+                        cls="mb-8",
+                    ),
+                    # Compact table
+                    Div(
+                        H3("Compact Table", cls="text-lg font-medium mb-2"),
+                        Table(
+                            TableHeader(
+                                TableRow(
+                                    TableHead("Product"),
+                                    TableHead("Price"),
+                                    TableHead("Stock"),
+                                    TableHead("Category"),
+                                )
+                            ),
+                            TableBody(
+                                TableRow(
+                                    TableCell("Laptop"),
+                                    TableCell("$999"),
+                                    TableCell("12"),
+                                    TableCell("Electronics"),
+                                ),
+                                TableRow(
+                                    TableCell("Mouse"),
+                                    TableCell("$29"),
+                                    TableCell("45"),
+                                    TableCell("Electronics"),
+                                ),
+                                TableRow(
+                                    TableCell("Keyboard"),
+                                    TableCell("$79"),
+                                    TableCell("8"),
+                                    TableCell("Electronics"),
+                                ),
+                            ),
+                            cls="text-xs [&_th]:h-8 [&_td]:p-1 [&_th]:p-1",
+                        ),
+                        cls="mb-8",
+                    ),
+                    cls="space-y-4 mb-8",
+                ),
+            ),
             # Form with validation example
             Div(
                 H2(


### PR DESCRIPTION
## Summary
- Add Table component with all sub-components (TableHeader, TableBody, TableFooter, TableRow, TableHead, TableCell, TableCaption)
- Match ShadCN table styling exactly with muted border-input borders
- Add Table to component metadata registry
- Add comprehensive table examples to test sandbox

## Test plan
- [x] Component follows StarUI patterns.md guidelines
- [x] Linting passes without issues
- [x] Table examples added to test sandbox
- [x] Border styling matches ShadCN with muted input borders
- [x] Component registered in metadata