### PR TITLE
feat: add iframe isolation for component previews and fix copy page functionality

### DIFF
--- a/docs/pages/components/alert.py
+++ b/docs/pages/components/alert.py
@@ -158,6 +158,7 @@ Alert(
         list(examples()),
         cli_command="star add alert",
         hero_example=hero_example,
+        component_slug="alert",
         api_reference={
             "props": [
                 {

--- a/docs/pages/components/badge.py
+++ b/docs/pages/components/badge.py
@@ -319,6 +319,7 @@ Badge("20+", variant="outline", cls="h-5 min-w-[1.25rem] rounded-full px-1 font-
         list(examples()),
         cli_command="star add badge",
         hero_example=hero_example,
+        component_slug="badge",
         api_reference={
             "props": [
                 {

--- a/docs/pages/components/breadcrumb.py
+++ b/docs/pages/components/breadcrumb.py
@@ -271,6 +271,7 @@ def create_breadcrumb_docs():
         list(examples()),
         cli_command="star add breadcrumb",
         hero_example=hero_example,
+        component_slug="breadcrumb",
         api_reference={
             "components": [
                 {

--- a/docs/pages/components/card.py
+++ b/docs/pages/components/card.py
@@ -363,6 +363,7 @@ def create_card_docs():
         list(examples()),
         cli_command="star add card",
         hero_example=hero_example,
+        component_slug="card",
         api_reference={
             "components": [
                 {

--- a/docs/pages/components/input.py
+++ b/docs/pages/components/input.py
@@ -287,6 +287,7 @@ Input(type="password", placeholder="Enter your password")'''
         list(examples()),
         cli_command="star add input",
         hero_example=hero_example,
+        component_slug="input",
         api_reference={
             "props": [
                 {

--- a/docs/pages/components/label.py
+++ b/docs/pages/components/label.py
@@ -344,6 +344,7 @@ Label(
         list(examples()),
         cli_command="star add label",
         hero_example=hero_example,
+        component_slug="label",
         api_reference={
             "props": [
                 {

--- a/docs/pages/components/tabs.py
+++ b/docs/pages/components/tabs.py
@@ -374,6 +374,7 @@ def create_tabs_docs():
         list(examples()),
         cli_command="star add tabs",
         hero_example=hero_example,
+        component_slug="tabs",
         api_reference={
             "props": [
                 {

--- a/docs/pages/components/theme_toggle.py
+++ b/docs/pages/components/theme_toggle.py
@@ -9,163 +9,225 @@ CATEGORY = "ui"
 ORDER = 95
 STATUS = "stable"
 
-from starhtml import Div, Icon, P, Span
+from starhtml import Div, H3, Icon, P, Span, FT
+from starhtml import Span as HTMLSpan
 from starhtml.datastar import ds_show, ds_on_click, ds_on_load, ds_signals, ds_effect, toggle
 from starui.registry.components.theme_toggle import ThemeToggle
 from starui.registry.components.button import Button
 from widgets.component_preview import ComponentPreview
 
 
+def IsolatedThemeToggle(alt_theme="dark", default_theme="light", **attrs) -> FT:
+    """Theme toggle that only affects its iframe container, not the parent document."""
+
+    return Div(
+        Button(
+            HTMLSpan(Icon("ph:moon-bold", width="20", height="20"), ds_show("!$isAlt")),
+            HTMLSpan(Icon("ph:sun-bold", width="20", height="20"), ds_show("$isAlt")),
+            ds_on_click("$isAlt = !$isAlt"),
+            variant="ghost",
+            aria_label="Toggle theme",
+            cls="h-9 px-4 py-2 flex-shrink-0",
+        ),
+        ds_signals(isAlt=False),
+        ds_on_load(
+            f"""
+            // Check iframe-specific storage first
+            const iframeKey = 'iframe-theme-' + window.location.pathname.split('/').pop();
+            const savedTheme = localStorage.getItem(iframeKey);
+            if (savedTheme) {{
+                $isAlt = savedTheme === '{alt_theme}';
+            }} else {{
+                // Fall back to system preference
+                $isAlt = window.matchMedia('(prefers-color-scheme: dark)').matches;
+            }}
+            """
+        ),
+        ds_effect(f"""
+            const theme = $isAlt ? '{alt_theme}' : '{default_theme}';
+            // Only affect the current document (iframe), not parent
+            document.documentElement.classList.toggle('{alt_theme}', $isAlt);
+            document.documentElement.setAttribute('data-theme', theme);
+            
+            // Store in iframe-specific key
+            const iframeKey = 'iframe-theme-' + window.location.pathname.split('/').pop();
+            localStorage.setItem(iframeKey, theme);
+        """),
+        **attrs,
+    )
+
+
 def examples():
     """Generate Theme Toggle examples using ComponentPreview with tabs."""
     
-    # Note: Basic theme toggle moved to hero example
-    # This will be the first example after the hero
-    
-    # Custom outline variant
-    yield ComponentPreview(
-        Div(
-            Button(
-                Span(
-                    Icon("ph:moon-bold", width="16", height="16"),
-                    ds_show("!$isDark")
-                ),
-                Span(
-                    Icon("ph:sun-bold", width="16", height="16"),
-                    ds_show("$isDark")
-                ),
-                ds_on_click(toggle("isDark")),
-                variant="outline",
-                size="sm",
-                aria_label="Toggle theme"
-            ),
-            ds_signals(isDark=False),
-            ds_on_load("""
-                const saved = localStorage.getItem('theme');
-                const systemDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-                $isDark = saved === 'dark' || (!saved && systemDark);
-            """),
-            ds_effect("""
-                const theme = $isDark ? 'dark' : 'light';
-                document.documentElement.setAttribute('data-theme', theme);
-                localStorage.setItem('theme', theme);
-            """),
-            cls="flex items-center justify-center"
-        ),
-        '''Button(
-    Span(
-        Icon("ph:moon-bold", width="16", height="16"),
-        ds_show("!$isDark")
-    ),
-    Span(
-        Icon("ph:sun-bold", width="16", height="16"),
-        ds_show("$isDark")
-    ),
-    ds_on_click(toggle("isDark")),
-    variant="outline",
-    aria_label="Toggle theme"
-)''',
-        title="Custom Toggle",
-        description="Custom implementation with outline button variant"
-    )
-    
-    # Multiple toggles with controls
+    # Sizes example - showing different button sizes
     yield ComponentPreview(
         Div(
             Div(
-                P("Theme Controls", cls="font-medium mb-3"),
+                P("Different Sizes", cls="font-medium mb-4"),
                 Div(
-                    ThemeToggle(cls="mr-2"),
-                    Button(
-                        "Reset Theme",
-                        ds_on_click("localStorage.removeItem('theme'); location.reload();"),
-                        variant="ghost",
-                        size="sm"
+                    # Small size
+                    Div(
+                        IsolatedThemeToggle(cls="scale-75"),
+                        P("Small", cls="text-xs text-muted-foreground mt-1"),
+                        cls="flex flex-col items-center"
                     ),
-                    cls="flex items-center gap-2"
+                    # Default size
+                    Div(
+                        IsolatedThemeToggle(),
+                        P("Default", cls="text-xs text-muted-foreground mt-1"),
+                        cls="flex flex-col items-center"
+                    ),
+                    # Large size
+                    Div(
+                        IsolatedThemeToggle(cls="scale-125"),
+                        P("Large", cls="text-xs text-muted-foreground mt-1"),
+                        cls="flex flex-col items-center"
+                    ),
+                    cls="flex items-start gap-8 justify-center"
+                ),
+            ),
+            cls="space-y-4"
+        ),
+        '''# Different sizes using CSS transforms
+ThemeToggle(cls="scale-75")   # Small
+ThemeToggle()                  # Default  
+ThemeToggle(cls="scale-125")   # Large''',
+        title="Size Variations",
+        description="Theme toggle in different sizes for various UI contexts",
+        use_iframe=True
+    )
+    
+    # Custom icons example
+    yield ComponentPreview(
+        Div(
+            Div(
+                P("Custom Icons", cls="font-medium mb-4"),
+                Div(
+                    # Sun/Moon (default)
+                    Div(
+                        IsolatedThemeToggle(),
+                        P("Sun/Moon", cls="text-xs text-muted-foreground mt-2"),
+                        cls="flex flex-col items-center"
+                    ),
+                    # Day/Night with different icons
+                    Div(
+                        Button(
+                            Span(Icon("lucide:sun-medium", width="20", height="20"), ds_show("!$isDark1")),
+                            Span(Icon("lucide:moon-star", width="20", height="20"), ds_show("$isDark1")),
+                            ds_on_click("$isDark1 = !$isDark1"),
+                            variant="ghost",
+                            aria_label="Toggle theme",
+                            cls="h-9 px-4 py-2"
+                        ),
+                        P("Day/Night", cls="text-xs text-muted-foreground mt-2"),
+                        ds_signals(isDark1=False),
+                        ds_on_load("$isDark1 = localStorage.getItem('theme') === 'dark'"),
+                        ds_effect("""
+                            const theme = $isDark1 ? 'dark' : 'light';
+                            document.documentElement.setAttribute('data-theme', theme);
+                            localStorage.setItem('theme', theme);
+                        """),
+                        cls="flex flex-col items-center"
+                    ),
+                    # Light/Dark text
+                    Div(
+                        Button(
+                            Span("Light", ds_show("!$isDark2")),
+                            Span("Dark", ds_show("$isDark2")),
+                            ds_on_click("$isDark2 = !$isDark2"),
+                            variant="outline",
+                            size="sm",
+                            aria_label="Toggle theme",
+                        ),
+                        P("Text Labels", cls="text-xs text-muted-foreground mt-2"),
+                        ds_signals(isDark2=False),
+                        ds_on_load("$isDark2 = localStorage.getItem('theme') === 'dark'"),
+                        ds_effect("""
+                            const theme = $isDark2 ? 'dark' : 'light';
+                            document.documentElement.setAttribute('data-theme', theme);
+                            localStorage.setItem('theme', theme);
+                        """),
+                        cls="flex flex-col items-center"
+                    ),
+                    cls="flex items-start gap-8 justify-center"
                 )
             ),
             cls="space-y-4"
         ),
-        '''Div(
-    ThemeToggle(),
-    Button(
-        "Reset Theme",
-        ds_on_click("localStorage.removeItem('theme'); location.reload();"),
-        variant="ghost",
-        size="sm"
-    ),
-    cls="flex items-center gap-2"
-)''',
-        title="With Controls",
-        description="Theme toggle with reset functionality"
-    )
-    
-    # Different button variants
-    yield ComponentPreview(
-        Div(
-            Div(
-                P("Button Variants", cls="font-medium mb-3"),
-                Div(
-                    ThemeToggle(),
-                    Button(
-                        Span(
-                            Icon("ph:moon-bold", width="16", height="16"),
-                            ds_show("!$theme2")
-                        ),
-                        Span(
-                            Icon("ph:sun-bold", width="16", height="16"), 
-                            ds_show("$theme2")
-                        ),
-                        ds_on_click(toggle("theme2")),
-                        variant="secondary",
-                        size="sm",
-                        aria_label="Toggle theme",
-                        cls="ml-2"
-                    ),
-                    Button(
-                        Span(
-                            Icon("ph:moon-bold", width="16", height="16"),
-                            ds_show("!$theme3")
-                        ),
-                        Span(
-                            Icon("ph:sun-bold", width="16", height="16"),
-                            ds_show("$theme3")
-                        ),
-                        ds_on_click(toggle("theme3")),
-                        variant="outline",
-                        size="sm",
-                        aria_label="Toggle theme",
-                        cls="ml-2"
-                    ),
-                    cls="flex items-center"
-                )
-            ),
-            ds_signals(theme2=False, theme3=False),
-            cls="space-y-4"
-        ),
-        '''# Ghost variant (default)
+        '''# Default icons
 ThemeToggle()
 
-# Secondary variant
+# Custom icons
 Button(
-    Span(Icon("ph:moon-bold"), ds_show("!$theme")),
-    Span(Icon("ph:sun-bold"), ds_show("$theme")),
-    ds_on_click(toggle("theme")),
-    variant="secondary",
-    aria_label="Toggle theme"
+    Span(Icon("lucide:sun-medium"), ds_show("!$isDark")),
+    Span(Icon("lucide:moon-star"), ds_show("$isDark")),
+    ds_on_click("$isDark = !$isDark"),
+    variant="ghost"
 )
 
-# Outline variant  
+# Text labels instead of icons
 Button(
-    Span(Icon("ph:moon-bold"), ds_show("!$theme")),
-    Span(Icon("ph:sun-bold"), ds_show("$theme")),
-    ds_on_click(toggle("theme")),
+    Span("Light", ds_show("!$isDark")),
+    Span("Dark", ds_show("$isDark")),
+    ds_on_click("$isDark = !$isDark"),
     variant="outline",
-    aria_label="Toggle theme"
+    size="sm"
 )''',
-        title="Button Variants",
-        description="Theme toggles using different button variants"
+        title="Custom Icons & Labels",
+        description="Different icon sets and text labels for theme switching",
+        use_iframe=True
+    )
+    
+    # Integration example - in a settings panel
+    yield ComponentPreview(
+        Div(
+            Div(
+                H3("Appearance Settings", cls="text-lg font-semibold"),
+                Div(
+                    Div(
+                        P("Theme", cls="text-sm font-medium"),
+                        P("Choose your preferred color scheme", cls="text-xs text-muted-foreground mt-1"),
+                        cls="flex-1"
+                    ),
+                    IsolatedThemeToggle(),
+                    cls="flex items-center justify-between"
+                ),
+                Div(
+                    Div(
+                        P("Auto-switch", cls="text-sm font-medium"),
+                        P("Follow system theme preference", cls="text-xs text-muted-foreground mt-1"),
+                        cls="flex-1 pr-4"
+                    ),
+                    Button(
+                        "Configure",
+                        variant="outline",
+                        size="sm",
+                        ds_on_click="alert('System preference settings')"
+                    ),
+                    cls="flex items-start justify-between border-t pt-4 gap-4"
+                ),
+                cls="bg-muted/30 rounded-lg p-6 w-full max-w-lg mx-auto space-y-4"
+            ),
+            cls="flex items-center justify-center min-h-[350px]"
+        ),
+        '''# Example: Settings panel integration
+Div(
+    H3("Appearance Settings", cls="text-lg font-semibold"),
+    Div(
+        Div(
+            P("Theme", cls="text-sm font-medium"),
+            P("Choose your preferred color scheme", cls="text-xs text-muted-foreground"),
+        ),
+        ThemeToggle(),
+        cls="flex items-center justify-between"
+    ),
+    cls="bg-muted/30 rounded-lg p-6"
+)''',
+        title="Settings Panel Integration",
+        description="Theme toggle integrated into a settings interface",
+        use_iframe=True,
+        iframe_height="450px"
     )
 
 
@@ -176,11 +238,12 @@ def create_theme_toggle_docs():
     # Hero example - basic theme toggle
     hero_example = ComponentPreview(
         Div(
-            ThemeToggle(),
+            IsolatedThemeToggle(),
             P("Click to toggle between light and dark themes", cls="text-sm text-muted-foreground mt-2"),
             cls="flex flex-col items-center"
         ),
-        '''ThemeToggle()'''
+        '''ThemeToggle()''',
+        use_iframe=True
     )
     
     return auto_generate_page(
@@ -189,6 +252,7 @@ def create_theme_toggle_docs():
         list(examples()),
         cli_command="star add theme-toggle",
         hero_example=hero_example,
+        component_slug="theme_toggle",
         api_reference={
             "props": [
                 {


### PR DESCRIPTION
## Summary
- Implement iframe isolation to prevent component interference with main docs (theme toggle affecting entire site)
- Add unified ComponentPreview with `use_iframe` parameter for selective isolation
- Fix copy page clipboard functionality to return complete markdown content instead of URLs
- Add dynamic markdown extraction system that works across all components without hardcoding
- Include component_slug parameters for proper API endpoint routing

## Test plan
- [x] Verify iframe isolation prevents theme toggle from affecting main docs
- [x] Test copy page functionality returns complete markdown with examples and API reference
- [x] Confirm all component pages have working copy buttons
- [x] Run ruff linting checks (all pass)
- [x] Run pytest test suite (72 tests pass)