### PR TITLE
feat: add command component

### DIFF
--- a/src/starui/registry/component_metadata.py
+++ b/src/starui/registry/component_metadata.py
@@ -69,6 +69,9 @@ COMPONENT_REGISTRY = {
     ),
     "card": _component("card", "Card container", ["utils"]),
     "checkbox": _component("checkbox", "Checkbox input", ["utils"]),
+    "command": _component(
+        "command", "Command palette interface", ["utils", "dialog", "button"]
+    ),
     "dropdown_menu": _component(
         "dropdown_menu", "Dropdown menu with items", ["utils", "button"], ["position"]
     ),

--- a/src/starui/registry/components/command.py
+++ b/src/starui/registry/components/command.py
@@ -1,0 +1,355 @@
+from typing import Any, Literal
+from uuid import uuid4
+
+from starhtml import FT, Div, Icon, Input, Span
+from starhtml import Dialog as HTMLDialog
+from starhtml.datastar import (
+    ds_attr,
+    ds_bind,
+    ds_effect,
+    ds_on,
+    ds_on_click,
+    ds_on_close,
+    ds_on_input,
+    ds_on_keydown,
+    ds_on_mouseenter,
+    ds_ref,
+    ds_signals,
+    value,
+)
+
+from .utils import cn, cva
+
+CommandSize = Literal["sm", "md", "lg"]
+_command_item_counters = {}
+
+
+def _get_filter_effect(signal: str) -> str:
+    return f"const i=document.querySelectorAll('[data-command-item=\"{signal}\"]'),s=${signal}_search.toLowerCase();let v=0;i.forEach(e=>{{const m=!s||(e.dataset.value||'').toLowerCase().includes(s)||(e.dataset.keywords||'').toLowerCase().includes(s)||(e.textContent||'').toLowerCase().includes(s);e.style.display=m?'':'none';e.dataset.filtered=m?'false':'true';m&&e.dataset.disabled!=='true'&&v++}});document.querySelectorAll('[data-command-group=\"{signal}\"]').forEach(g=>{{g.style.display=Array.from(g.querySelectorAll('[data-command-item=\"{signal}\"]')).some(i=>i.dataset.filtered==='false')?'':'none'}});document.querySelectorAll('[data-command-empty=\"{signal}\"]').forEach(e=>{{e.style.display=v>0?'none':''}});"
+
+
+def _get_search_handler(signal: str) -> str:
+    return f"clearTimeout(window._st_{signal});window._st_{signal}=setTimeout(()=>{{const v=document.querySelectorAll('[data-command-item=\"{signal}\"]:not([style*=\"none\"]):not([data-disabled=\"true\"])');if(v.length>0)${signal}_selected=parseInt(v[0].dataset.index||'0')}},50)"
+
+
+def _get_nav_handler(signal: str, ref_id: str = None) -> str:
+    escape_check = f"!document.getElementById('{ref_id}')" if ref_id else "true"
+    return f"const i=[...document.querySelectorAll('[data-command-item=\"{signal}\"]:not([data-filtered=\"true\"]):not([data-disabled=\"true\"])')];let c=-1;i.forEach((e,x)=>{{if(parseInt(e.dataset.index)===${signal}_selected)c=x}});switch(event.key){{case'ArrowDown':event.preventDefault();if(i.length>0){{const n=c<i.length-1?c+1:0;${signal}_selected=parseInt(i[n].dataset.index);i[n].scrollIntoView({{block:'nearest'}})}}break;case'ArrowUp':event.preventDefault();if(i.length>0){{const p=c>0?c-1:i.length-1;${signal}_selected=parseInt(i[p].dataset.index);i[p].scrollIntoView({{block:'nearest'}})}}break;case'Enter':event.preventDefault();if(c>=0&&i[c])i[c].click();break;case'Escape':if({escape_check}){{event.preventDefault();${signal}_search='';${signal}_selected=0}}break}}"
+
+
+def _get_dialog_open_effect(signal: str, ref_id: str) -> str:
+    return f"{_get_filter_effect(signal)};if(${ref_id}_open&&!${signal}_search)setTimeout(()=>{{const f=document.querySelector('[data-command-item=\"{signal}\"]:not([data-disabled=\"true\"])');if(f)${signal}_selected=parseInt(f.dataset.index||'0')}},50)"
+
+
+def _init_command_signals(signal: str) -> dict:
+    return {f"{signal}_search": value(""), f"{signal}_selected": 0}
+
+
+def _process_children(children, signal):
+    return [c(signal) if callable(c) else c for c in children]
+
+command_variants = cva(
+    base="flex w-full flex-col overflow-hidden rounded-lg border border-input bg-popover text-popover-foreground shadow-md",
+    config={
+        "variants": {
+            "size": {
+                "sm": "max-h-[300px]",
+                "md": "max-h-[400px] md:min-w-[450px]",
+                "lg": "max-h-[500px] md:min-w-[450px]",
+            }
+        },
+        "defaultVariants": {"size": "md"},
+    },
+)
+
+
+def Command(
+    *children: Any,
+    signal: str | None = None,
+    size: CommandSize = "md",
+    class_name: str = "",
+    cls: str = "",
+    **attrs: Any,
+) -> FT:
+    signal = signal or f"command_{uuid4().hex[:8]}"
+
+    global _command_item_counters
+    _command_item_counters[signal] = 0
+
+    return Div(
+        *_process_children(children, signal),
+        ds_signals(**_init_command_signals(signal)),
+        ds_effect(_get_filter_effect(signal)),
+        data_command_root=signal,
+        data_slot="command",
+        tabindex="-1",
+        cls=cn(command_variants(size=size), class_name, cls),
+        **attrs,
+    )
+
+
+def CommandDialog(
+    trigger: FT,
+    content: list[FT],
+    signal: str | None = None,
+    modal: bool = True,
+    class_name: str = "",
+    cls: str = "",
+    **attrs: Any,
+) -> FT:
+    signal = signal or f"command_{uuid4().hex[:8]}"
+    ref_id = f"{signal}_dialog"
+    signal_open = f"{ref_id}_open"
+
+    global _command_item_counters
+    _command_item_counters[signal] = 0
+
+    reset_signals = f"${signal_open}=false;${signal}_search='';${signal}_selected=0;document.body.style.overflow=''"
+
+    dialog_attrs = [
+        ds_signals(**{**_init_command_signals(signal), signal_open: False}),
+        ds_ref(ref_id),
+        ds_on_close(reset_signals),
+        ds_on_keydown(f"if(evt.key==='Escape'){{evt.preventDefault();const d=document.getElementById('{ref_id}');if(d){{d.close();d.style.display='none';{reset_signals};setTimeout(()=>{{d.style.display=''}},100)}}}}"),
+        ds_effect(_get_dialog_open_effect(signal, ref_id)),
+    ]
+
+    if modal:
+        dialog_attrs.append(
+            ds_on("click", f"if(evt.target===evt.currentTarget){{evt.currentTarget.close();{reset_signals}}}")
+        )
+
+    command_dialog = HTMLDialog(
+        *_process_children(content, signal),
+        *dialog_attrs,
+        id=ref_id,
+        data_command_root=signal,
+        data_slot="command",
+        tabindex="-1",
+        cls=cn(
+            "fixed max-h-[85vh] w-full max-w-2xl overflow-auto m-auto p-0",
+            "backdrop:bg-black/50 backdrop:backdrop-blur-sm",
+            "open:animate-in open:fade-in-0 open:zoom-in-95 open:duration-200",
+            "open:backdrop:animate-in open:backdrop:fade-in-0 open:backdrop:duration-200",
+            "flex flex-col overflow-hidden rounded-lg",
+            "border border-input bg-popover text-popover-foreground shadow-lg",
+            "md:min-w-[450px]",
+            class_name,
+            cls,
+        ),
+        **attrs,
+    )
+
+    method = "showModal" if modal else "show"
+    trigger_elem = Div(
+        trigger,
+        ds_on_click(f"${ref_id}.{method}();${signal_open}=true"),
+        style="display:contents"
+    )
+
+    scroll_lock = Div(
+        ds_effect(f"document.body.style.overflow=${signal_open}?'hidden':''"),
+        style="display:none",
+    )
+
+    return Div(trigger_elem, command_dialog, scroll_lock)
+
+
+def CommandInput(
+    placeholder: str = "Type a command or search...",
+    class_name: str = "",
+    cls: str = "",
+    **attrs: Any,
+):
+    def _(signal):
+        return Div(
+            Icon("lucide:search", cls="size-4 shrink-0 opacity-50"),
+            Input(
+                ds_bind(f"{signal}_search"),
+                ds_on_keydown(_get_nav_handler(signal, f"{signal}_dialog")),
+                ds_on_input(_get_search_handler(signal)),
+                placeholder=placeholder,
+                data_slot="command-input",
+                cls="flex h-10 w-full rounded-md bg-transparent py-3 text-sm outline-none placeholder:text-muted-foreground disabled:cursor-not-allowed disabled:opacity-50",
+                autocomplete="off",
+                autocorrect="off",
+                spellcheck="false",
+                type="text",
+                **attrs,
+            ),
+            data_slot="command-input-wrapper",
+            cls=cn("flex h-9 items-center gap-2 border-b border-border px-3", class_name, cls),
+        )
+
+    return _
+
+
+def CommandList(
+    *children,
+    class_name: str = "",
+    cls: str = "",
+    **attrs: Any,
+):
+    def _(signal):
+        return Div(
+            *_process_children(children, signal),
+            role="listbox",
+            aria_label="Commands",
+            data_command_list=signal,
+            data_slot="command-list",
+            cls=cn(
+                "max-h-[300px] scroll-py-1 overflow-x-hidden overflow-y-auto",
+                class_name,
+                cls,
+            ),
+            **attrs,
+        )
+
+    return _
+
+
+def CommandEmpty(
+    *children,
+    class_name: str = "",
+    cls: str = "",
+    **attrs: Any,
+):
+    def _(signal):
+        return Div(
+            *(children or ["No results found."]),
+            data_command_empty=signal,
+            data_slot="command-empty",
+            style="display: none;",
+            cls=cn("py-6 text-center text-sm", class_name, cls),
+            **attrs,
+        )
+
+    return _
+
+
+def CommandGroup(
+    *children,
+    heading: str | None = None,
+    class_name: str = "",
+    cls: str = "",
+    **attrs: Any,
+):
+    def _(signal):
+        return Div(
+            *([Div(
+                heading,
+                data_slot="command-group-heading",
+                cls="text-muted-foreground px-2 py-1.5 text-xs font-medium",
+                aria_hidden="true",
+            )] if heading else []),
+            *_process_children(children, signal),
+            role="group",
+            data_command_group=signal,
+            data_slot="command-group",
+            cls=cn(
+                "overflow-hidden p-1 text-foreground",
+                "[&_[data-slot='command-group-heading']]:text-muted-foreground",
+                "[&_[data-slot='command-group-heading']]:px-2",
+                "[&_[data-slot='command-group-heading']]:py-1.5",
+                "[&_[data-slot='command-group-heading']]:text-xs",
+                "[&_[data-slot='command-group-heading']]:font-medium",
+                class_name,
+                cls,
+            ),
+            **attrs,
+        )
+
+    return _
+
+
+def CommandItem(
+    *children,
+    value: str,
+    onclick: str | None = None,
+    disabled: bool = False,
+    keywords: str | None = None,
+    class_name: str = "",
+    cls: str = "",
+    **attrs: Any,
+):
+    def _(signal):
+        index = attrs.pop("index", attrs.pop("data_index", None))
+
+        if index is None:
+            global _command_item_counters
+            _command_item_counters.setdefault(signal, 0)
+            index = _command_item_counters[signal]
+            _command_item_counters[signal] += 1
+
+        event_attrs = []
+        if not disabled:
+            if onclick:
+                click_handler = f"{onclick};const d=document.querySelector('dialog[data-command-root=\"{signal}\"]');if(d){{d.close();d.style.display='none';${signal}_dialog_open=false;${signal}_search='';${signal}_selected=0;document.body.style.overflow='';setTimeout(()=>{{d.style.display=''}},100)}}"
+                event_attrs.append(ds_on_click(click_handler))
+            event_attrs.append(ds_on_mouseenter(f"${signal}_selected={index}"))
+
+        return Div(
+            *children,
+            *event_attrs,
+            ds_attr(data_selected=f"${signal}_selected==={index}?'true':'false'"),
+            role="option",
+            aria_selected=f"${{{signal}_selected}} === {index}",
+            aria_disabled="true" if disabled else "false",
+            data_command_item=signal,
+            data_slot="command-item",
+            data_value=value,
+            data_keywords=keywords or "",
+            data_disabled="true" if disabled else "false",
+            data_index=str(index),
+            cls=cn(
+                "relative flex cursor-default items-center gap-2 rounded-sm px-2 py-1.5",
+                "text-sm outline-none select-none transition-colors",
+                "hover:bg-accent/50 data-[selected=true]:bg-accent data-[selected=true]:text-accent-foreground" if not disabled else "",
+                "[&_svg:not([class*='text-'])]:text-muted-foreground",
+                "opacity-50 cursor-not-allowed pointer-events-none" if disabled else "",
+                "[&_svg]:pointer-events-none [&_svg]:shrink-0 [&_svg:not([class*='size-'])]:size-4",
+                class_name,
+                cls,
+            ),
+            **attrs,
+        )
+
+    return _
+
+
+def CommandSeparator(class_name: str = "", cls: str = "", **attrs: Any):
+    return lambda signal: Div(
+        role="separator",
+        data_slot="command-separator",
+        cls=cn("-mx-1 h-px bg-border", class_name, cls),
+        **attrs,
+    )
+
+
+def CommandDialogWithTrigger(
+    trigger: FT,
+    content: FT | list,
+    **kwargs
+) -> FT:
+    """Backward compatibility wrapper."""
+    if not isinstance(content, list | tuple):
+        content = [content]
+    return CommandDialog(*content, trigger=trigger, **kwargs)
+
+
+def CommandShortcut(
+    *children,
+    class_name: str = "",
+    cls: str = "",
+    **attrs: Any,
+) -> FT:
+    return Span(
+        *children,
+        data_slot="command-shortcut",
+        cls=cn(
+            "ml-auto text-xs tracking-widest text-muted-foreground",
+            class_name,
+            cls,
+        ),
+        **attrs,
+    )

--- a/test_sandbox/app.py
+++ b/test_sandbox/app.py
@@ -6,6 +6,10 @@ from starhtml.datastar import value
 # Import all registry components at once (this will override starhtml components)
 from registry_loader import *
 from src.starui.registry.components.toast import Toaster, toast, success_toast, error_toast, warning_toast, info_toast
+from src.starui.registry.components.command import (
+    Command, CommandDialog, CommandInput, CommandList, CommandEmpty,
+    CommandGroup, CommandItem, CommandSeparator, CommandShortcut
+)
 
 styles = Link(rel="stylesheet", href="/static/css/starui.css", type="text/css")
 
@@ -1808,6 +1812,294 @@ def index():
                             cls="text-xs [&_th]:h-8 [&_td]:p-1 [&_th]:p-1",
                         ),
                         cls="mb-8",
+                    ),
+                    cls="space-y-4 mb-8",
+                ),
+            ),
+            # Command examples
+            Div(
+                H2("Command", cls="text-2xl font-semibold mb-4"),
+                Div(
+                    # Basic Command palette
+                    Div(
+                        H3("Basic Command Palette", cls="text-lg font-medium mb-2"),
+                        Command(
+                            CommandInput(placeholder="Type a command or search..."),
+                            CommandList(
+                                CommandEmpty("No results found."),
+                                CommandGroup(
+                                    CommandItem(
+                                        Icon("lucide:file"),
+                                        Span("New File", cls="ml-2"),
+                                        value="new-file",
+                                        onclick="console.log('New file')",
+                                        data_index=0,
+                                    ),
+                                    CommandItem(
+                                        Icon("lucide:folder"),
+                                        Span("New Folder", cls="ml-2"),
+                                        value="new-folder",
+                                        onclick="console.log('New folder')",
+                                        data_index=1,
+                                    ),
+                                    CommandItem(
+                                        Icon("lucide:save"),
+                                        Span("Save", cls="ml-2"),
+                                        CommandShortcut("⌘S"),
+                                        value="save",
+                                        onclick="console.log('Save')",
+                                        data_index=2,
+                                    ),
+                                    heading="File",
+                                ),
+                                CommandSeparator(),
+                                CommandGroup(
+                                    CommandItem(
+                                        Icon("lucide:settings"),
+                                        Span("Settings", cls="ml-2"),
+                                        CommandShortcut("⌘,"),
+                                        value="settings",
+                                        onclick="console.log('Settings')",
+                                        data_index=3,
+                                    ),
+                                    CommandItem(
+                                        Icon("lucide:user"),
+                                        Span("Profile", cls="ml-2"),
+                                        value="profile",
+                                        onclick="console.log('Profile')",
+                                        data_index=4,
+                                    ),
+                                    CommandItem(
+                                        Icon("lucide:log-out"),
+                                        Span("Log Out", cls="ml-2"),
+                                        value="logout",
+                                        onclick="console.log('Logout')",
+                                        data_index=5,
+                                    ),
+                                    heading="User",
+                                ),
+                            ),
+                            signal="basic_command",
+                            size="md",
+                            cls="max-w-md",
+                        ),
+                        cls="mb-6",
+                    ),
+                    # Command Dialog
+                    Div(
+                        H3("Command Dialog", cls="text-lg font-medium mb-2"),
+                        CommandDialog(
+                            trigger=Button(
+                                Icon("lucide:terminal"),
+                                Span("Open Command Palette", cls="ml-2"),
+                                variant="outline",
+                            ),
+                            content=[
+                                CommandInput(placeholder="Search commands..."),
+                                CommandList(
+                                    CommandEmpty("No commands found."),
+                                    CommandGroup(
+                                        CommandItem(
+                                            Icon("lucide:copy"),
+                                            Span("Copy", cls="ml-2"),
+                                            CommandShortcut("⌘C"),
+                                            value="copy",
+                                            onclick="console.log('Copy'); document.getElementById('cmd_dialog_dialog').close()",
+                                            data_index=0,
+                                        ),
+                                        CommandItem(
+                                            Icon("lucide:clipboard"),
+                                            Span("Paste", cls="ml-2"),
+                                            CommandShortcut("⌘V"),
+                                            value="paste",
+                                            onclick="console.log('Paste'); document.getElementById('cmd_dialog_dialog').close()",
+                                            data_index=1,
+                                        ),
+                                        CommandItem(
+                                            Icon("lucide:scissors"),
+                                            Span("Cut", cls="ml-2"),
+                                            CommandShortcut("⌘X"),
+                                            value="cut",
+                                            onclick="console.log('Cut'); document.getElementById('cmd_dialog_dialog').close()",
+                                            data_index=2,
+                                        ),
+                                        heading="Edit",
+                                    ),
+                                    CommandSeparator(),
+                                    CommandGroup(
+                                        CommandItem(
+                                            Icon("lucide:layout"),
+                                            Span("Toggle Sidebar", cls="ml-2"),
+                                            CommandShortcut("⌘B"),
+                                            value="toggle-sidebar",
+                                            onclick="console.log('Toggle sidebar'); document.getElementById('cmd_dialog_dialog').close()",
+                                            data_index=3,
+                                        ),
+                                        CommandItem(
+                                            Icon("lucide:moon"),
+                                            Span("Toggle Theme", cls="ml-2"),
+                                            CommandShortcut("⌘T"),
+                                            value="toggle-theme",
+                                            onclick="console.log('Toggle theme'); document.getElementById('cmd_dialog_dialog').close()",
+                                            data_index=4,
+                                        ),
+                                        heading="View",
+                                    ),
+                                    CommandSeparator(),
+                                    CommandGroup(
+                                        CommandItem(
+                                            Icon("lucide:help-circle"),
+                                            Span("Help", cls="ml-2"),
+                                            CommandShortcut("⌘?"),
+                                            value="help",
+                                            onclick="console.log('Help'); document.getElementById('cmd_dialog_dialog').close()",
+                                            data_index=5,
+                                        ),
+                                        CommandItem(
+                                            Icon("lucide:keyboard"),
+                                            Span("Keyboard Shortcuts", cls="ml-2"),
+                                            value="shortcuts",
+                                            onclick="console.log('Shortcuts'); document.getElementById('cmd_dialog_dialog').close()",
+                                            data_index=6,
+                                        ),
+                                        heading="Help",
+                                    ),
+                                ),
+                            ],
+                            signal="cmd_dialog",
+                        ),
+                        cls="mb-6",
+                    ),
+                    # Command with search example
+                    Div(
+                        H3("Searchable Command Palette", cls="text-lg font-medium mb-2"),
+                        Command(
+                            CommandInput(placeholder="Search frameworks..."),
+                            CommandList(
+                                CommandEmpty("No framework found."),
+                                CommandGroup(
+                                    CommandItem(
+                                        "React",
+                                        value="react",
+                                        keywords="javascript frontend",
+                                        onclick="alert('Selected: React')",
+                                        data_index=0,
+                                    ),
+                                    CommandItem(
+                                        "Vue",
+                                        value="vue",
+                                        keywords="javascript frontend",
+                                        onclick="alert('Selected: Vue')",
+                                        data_index=1,
+                                    ),
+                                    CommandItem(
+                                        "Angular",
+                                        value="angular",
+                                        keywords="typescript frontend",
+                                        onclick="alert('Selected: Angular')",
+                                        data_index=2,
+                                    ),
+                                    heading="Frontend",
+                                ),
+                                CommandSeparator(),
+                                CommandGroup(
+                                    CommandItem(
+                                        "Django",
+                                        value="django",
+                                        keywords="python backend",
+                                        onclick="alert('Selected: Django')",
+                                        data_index=3,
+                                    ),
+                                    CommandItem(
+                                        "FastAPI",
+                                        value="fastapi",
+                                        keywords="python backend api",
+                                        onclick="alert('Selected: FastAPI')",
+                                        data_index=4,
+                                    ),
+                                    CommandItem(
+                                        "Express",
+                                        value="express",
+                                        keywords="javascript nodejs backend",
+                                        onclick="alert('Selected: Express')",
+                                        data_index=5,
+                                    ),
+                                    heading="Backend",
+                                ),
+                                CommandSeparator(),
+                                CommandGroup(
+                                    CommandItem(
+                                        "Next.js",
+                                        value="nextjs",
+                                        keywords="react fullstack",
+                                        onclick="alert('Selected: Next.js')",
+                                        data_index=6,
+                                    ),
+                                    CommandItem(
+                                        "Nuxt",
+                                        value="nuxt",
+                                        keywords="vue fullstack",
+                                        onclick="alert('Selected: Nuxt')",
+                                        data_index=7,
+                                    ),
+                                    CommandItem(
+                                        "SvelteKit",
+                                        value="sveltekit",
+                                        keywords="svelte fullstack",
+                                        onclick="alert('Selected: SvelteKit')",
+                                        data_index=8,
+                                    ),
+                                    heading="Full Stack",
+                                ),
+                            ),
+                            signal="framework_command",
+                            size="lg",
+                            cls="max-w-md",
+                        ),
+                        cls="mb-6",
+                    ),
+                    # Command with disabled items
+                    Div(
+                        H3("Command with Disabled Items", cls="text-lg font-medium mb-2"),
+                        Command(
+                            CommandInput(placeholder="Search actions..."),
+                            CommandList(
+                                CommandEmpty("No action found."),
+                                CommandItem(
+                                    Icon("lucide:check"),
+                                    Span("Available Action", cls="ml-2"),
+                                    value="available",
+                                    onclick="alert('Action executed')",
+                                    data_index=0,
+                                ),
+                                CommandItem(
+                                    Icon("lucide:lock"),
+                                    Span("Premium Feature", cls="ml-2"),
+                                    Badge("Pro", variant="secondary", cls="ml-auto"),
+                                    value="premium",
+                                    disabled=True,
+                                    data_index=1,
+                                ),
+                                CommandItem(
+                                    Icon("lucide:shield"),
+                                    Span("Admin Only", cls="ml-2"),
+                                    value="admin",
+                                    disabled=True,
+                                    data_index=2,
+                                ),
+                                CommandItem(
+                                    Icon("lucide:play"),
+                                    Span("Run Task", cls="ml-2"),
+                                    value="run",
+                                    onclick="alert('Task started')",
+                                    data_index=3,
+                                ),
+                            ),
+                            signal="disabled_command",
+                            size="sm",
+                            cls="max-w-md",
+                        ),
+                        cls="mb-6",
                     ),
                     cls="space-y-4 mb-8",
                 ),


### PR DESCRIPTION
## Summary
- Adds a comprehensive command palette component
- Supports dialog mode with triggers  
- Includes search and keyboard navigation
- Full accessibility with ARIA attributes
- Clean, minified JavaScript for performance

## Components Added
- `Command` - Basic command palette container
- `CommandDialog` - Modal command palette with trigger
- `CommandInput` - Search input with navigation
- `CommandList` - Scrollable list container
- `CommandItem` - Individual command items with selection
- `CommandGroup` - Grouped commands with headings
- `CommandEmpty` - Empty state display
- `CommandSeparator` - Visual dividers
- `CommandShortcut` - Keyboard shortcut display

## Test Plan
- [x] All existing tests pass
- [x] Component imports correctly
- [x] Renders HTML with proper structure
- [x] Accessibility attributes present
- [x] Event handlers configured
- [x] Ruff linting passes

🤖 Generated with [Claude Code](https://claude.ai/code)