### PR TITLE
Add Field component and bump starhtml to >=0.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - `Field` component — composable form field primitives with auto-wired IDs, client-side validation (`validate=`), responsive orientation, and error-state propagation. Includes `FieldSet`, `FieldLegend`, `FieldGroup`, `FieldContent`, `FieldLabel`, `FieldDescription`, `FieldSeparator`, and `FieldError`.
-- Requires starhtml >=0.5.21 for `Signal.validate()` and `form_submit` APIs
+
+### Changed
+- Bump `starhtml` dependency from `>=0.5.21` to `>=0.6.0` (starlette 1.0 compatibility, built-in form handling)
 
 ## [0.4.2] - 2026-03-13
 

--- a/docs/pages/components/field.py
+++ b/docs/pages/components/field.py
@@ -46,13 +46,13 @@ def orientation_example():
     return FieldGroup(
         Field(
             FieldLabel("Display name"),
-            Input(placeholder="Jane Doe", cls="flex-1"),
+            Input(placeholder="Jane Doe"),
             orientation="responsive",
             name="ori-name",
         ),
         Field(
             FieldLabel("Username"),
-            Input(placeholder="janedoe", cls="flex-1"),
+            Input(placeholder="janedoe"),
             orientation="responsive",
             name="ori-user",
         ),
@@ -227,7 +227,7 @@ EXAMPLES_DATA = [
 API_REFERENCE = build_api_reference(
     components=[
         Component("Field", "Accessible wrapper with orientation, validation, and error-state propagation via data-invalid", [
-            Prop("name", "str | None", "Auto-wires coordinated IDs across label, a single primary text-like control, description, and error. If multiple eligible controls are present, Field does not guess.", "None"),
+            Prop("name", "str | None", "Auto-wires coordinated IDs across label, a single primary text-like control, description, and error. Also sets the HTML name attribute on the control for form submission (dashes converted to underscores). If multiple eligible controls are present, Field does not guess.", "None"),
             Prop("orientation", "Literal['vertical', 'horizontal', 'responsive']", "Layout direction", "'vertical'"),
             Prop("invalid", "bool | Signal | None", "Error state \u2014 True for static, Signal for reactive (auto-set when validate= is used)", "None"),
             Prop("validate", "callable | tuple | None", "Validation rule \u2014 email, (min_length, 8, 'Label'), or (matches, other_sig, 'msg'). Auto-creates signal, wires Input, FieldError, and invalid.", "None"),

--- a/docs/pyproject.toml
+++ b/docs/pyproject.toml
@@ -5,7 +5,7 @@ description = "Documentation for StarUI component library"
 readme = "README.md"
 requires-python = ">=3.12"
 dependencies = [
-    "starhtml>=0.5.21",
+    "starhtml>=0.6.0",
     "starlighter>=0.2.0",
     "starui",
     "uvicorn>=0.30.0",

--- a/docs/uv.lock
+++ b/docs/uv.lock
@@ -805,8 +805,8 @@ wheels = [
 
 [[package]]
 name = "starhtml"
-version = "0.5.21"
-source = { registry = "https://pypi.org/simple" }
+version = "0.5.24"
+source = { editable = "../../starhtml-upstream" }
 dependencies = [
     { name = "beautifulsoup4" },
     { name = "fastcore" },
@@ -821,22 +821,60 @@ dependencies = [
     { name = "starlette-compress" },
     { name = "uvicorn", extra = ["standard"] },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/4c/ed/6394bb3d97e0f7d35513c5c95899e0de6c7884a50b68e63ac0907c8f2cb7/starhtml-0.5.21.tar.gz", hash = "sha256:ddad2bfea1fa53454b4dd9c2b3caa12c70d42b55e3c245a02949211e7dc1bf30", size = 777596, upload-time = "2026-03-27T04:57:56.789Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/84/11/29f9418856683895871761d4fb860f1374114309618670de6efdce6a40ab/starhtml-0.5.21-py3-none-any.whl", hash = "sha256:896ab0352057934fd7de63dde1589d92afb6aaad2a111174eb33ae57ec90e128", size = 151699, upload-time = "2026-03-27T04:57:55.431Z" },
+
+[package.metadata]
+requires-dist = [
+    { name = "beautifulsoup4" },
+    { name = "brotli", marker = "extra == 'dev'", specifier = ">=1.1.0" },
+    { name = "fastcore" },
+    { name = "fastlite" },
+    { name = "httpx" },
+    { name = "ipykernel", marker = "extra == 'dev'" },
+    { name = "itsdangerous" },
+    { name = "oauthlib" },
+    { name = "pip-tools", marker = "extra == 'dev'" },
+    { name = "psutil", marker = "extra == 'dev'" },
+    { name = "pyright", marker = "extra == 'dev'" },
+    { name = "pytest", marker = "extra == 'test'" },
+    { name = "pytest-asyncio", marker = "extra == 'test'" },
+    { name = "pytest-cov", marker = "extra == 'test'", specifier = ">=6.1.1" },
+    { name = "pytest-timeout", marker = "extra == 'test'" },
+    { name = "pytest-watch", marker = "extra == 'test'" },
+    { name = "pytest-xdist", marker = "extra == 'test'" },
+    { name = "python-dateutil" },
+    { name = "python-multipart", specifier = ">=0.0.20" },
+    { name = "requests", marker = "extra == 'test'", specifier = ">=2.32.4" },
+    { name = "rjsmin", specifier = ">=1.2.4" },
+    { name = "ruff", marker = "extra == 'dev'" },
+    { name = "star-drawing", marker = "extra == 'demo'", specifier = ">=0.1.0" },
+    { name = "starelements", marker = "extra == 'debug'", specifier = ">=0.1.1" },
+    { name = "starelements", marker = "extra == 'demo'", specifier = ">=0.1.1" },
+    { name = "starlette", specifier = "~=1.0" },
+    { name = "starlette-compress", specifier = ">=1.0.0" },
+    { name = "starlighter", marker = "extra == 'demo'" },
+    { name = "uvicorn", extras = ["standard"] },
+]
+provides-extras = ["test", "dev", "debug", "demo"]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "psutil", specifier = ">=7.0.0" },
+    { name = "pytest-asyncio", specifier = ">=1.1.0" },
+    { name = "pytest-cov", specifier = ">=6.1.1" },
+    { name = "python-multipart", specifier = ">=0.0.20" },
 ]
 
 [[package]]
 name = "starlette"
-version = "0.52.1"
+version = "1.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/c4/68/79977123bb7be889ad680d79a40f339082c1978b5cfcf62c2d8d196873ac/starlette-0.52.1.tar.gz", hash = "sha256:834edd1b0a23167694292e94f597773bc3f89f362be6effee198165a35d62933", size = 2653702, upload-time = "2026-01-18T13:34:11.062Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/81/69/17425771797c36cded50b7fe44e850315d039f28b15901ab44839e70b593/starlette-1.0.0.tar.gz", hash = "sha256:6a4beaf1f81bb472fd19ea9b918b50dc3a77a6f2e190a12954b25e6ed5eea149", size = 2655289, upload-time = "2026-03-22T18:29:46.779Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/81/0d/13d1d239a25cbfb19e740db83143e95c772a1fe10202dda4b76792b114dd/starlette-0.52.1-py3-none-any.whl", hash = "sha256:0029d43eb3d273bc4f83a08720b4912ea4b071087a3b48db01b7c839f7954d74", size = 74272, upload-time = "2026-01-18T13:34:09.188Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/c9/584bc9651441b4ba60cc4d557d8a547b5aff901af35bda3a4ee30c819b82/starlette-1.0.0-py3-none-any.whl", hash = "sha256:d3ec55e0bb321692d275455ddfd3df75fff145d009685eb40dc91fc66b03d38b", size = 72651, upload-time = "2026-03-22T18:29:45.111Z" },
 ]
 
 [[package]]
@@ -909,7 +947,7 @@ dev = [
 
 [package.metadata]
 requires-dist = [
-    { name = "starhtml", specifier = ">=0.5.21" },
+    { name = "starhtml", editable = "../../starhtml-upstream" },
     { name = "starlighter", specifier = ">=0.2.0" },
     { name = "starui" },
     { name = "uvicorn", specifier = ">=0.30.0" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "pydantic>=2.5.0,<3.0.0",
     "rich>=13.7.0,<14.0.0",
     "websockets>=12.0.0,<16.0.0",
-    "starhtml>=0.5.21",
+    "starhtml>=0.6.0",
     "starmerge>=0.2.0",
 ]
 

--- a/registry/components/field.py
+++ b/registry/components/field.py
@@ -11,16 +11,15 @@ from .utils import cn, inject_context, with_signals
 __metadata__ = {"description": "Accessible form field composition", "dependencies": ["separator"]}
 
 _FIELD_ORIENTATION = {
-    "vertical": "flex-col [&>*]:w-full [&>.sr-only]:w-auto",
+    "vertical": "flex flex-col [&>*]:w-full [&>.sr-only]:w-auto @md/field-group:col-span-2",
     "horizontal": (
-        "flex-row items-center [&>[data-slot=field-label]]:flex-auto"
+        "grid grid-cols-[auto_1fr] items-center"
         " has-[>[data-slot=field-content]]:items-start"
         " has-[>[data-slot=field-content]]:[&>[role=checkbox],[role=radio]]:mt-px"
     ),
     "responsive": (
-        "flex-col @md/field-group:flex-row @md/field-group:items-center"
+        "flex flex-col @md/field-group:col-span-2 @md/field-group:grid @md/field-group:grid-cols-subgrid @md/field-group:items-center"
         " [&>*]:w-full @md/field-group:[&>*]:w-auto [&>.sr-only]:w-auto"
-        " @md/field-group:[&>[data-slot=field-label]]:flex-auto"
         " @md/field-group:has-[>[data-slot=field-content]]:items-start"
         " @md/field-group:has-[>[data-slot=field-content]]:[&>[role=checkbox],[role=radio]]:mt-px"
     ),
@@ -30,9 +29,11 @@ _DISABLED_FIELD = "group-data-[disabled=true]/field:pointer-events-none group-da
 
 
 def _is_autowire_control(node: FT) -> bool:
-    if node.get("data-field-control") == "true":
-        return True
-    return node.tag == "textarea" or (node.tag == "input" and node.get("type") not in {"checkbox", "hidden", "radio"})
+    return (
+        node.get("data-field-control") == "true"
+        or node.tag == "textarea"
+        or (node.tag == "input" and node.get("type") not in {"checkbox", "hidden", "radio"})
+    )
 
 
 def _find_autowire_control(nodes) -> FT | None:
@@ -69,7 +70,7 @@ def Field(
     **kwargs,
 ) -> FT:
     field_signal = signal
-    if validate is not None and name:
+    if validate and name:
         field_signal = field_signal or Signal(name.replace("-", "_"), "")
         fn, *rest = validate if isinstance(validate, tuple) else (validate,)
         kw = rest.pop() if rest and isinstance(rest[-1], dict) else {}
@@ -79,8 +80,9 @@ def Field(
     children = tuple(inject_context(child, name=name, signal=field_signal) for child in children)
     if name and (inp := _find_autowire_control(children)) and not inp.get("id"):
         inp.list[2] |= {"id": name, "aria-describedby": f"{name}-desc {name}-error"}
+        inp.list[2].setdefault("name", name.replace("-", "_"))
         if field_signal:
-            for k, v in field_signal._validate_html.items():
+            for k, v in field_signal._constraint_attrs.items():
                 inp.list[2].setdefault(k, v)
 
     result = Div(
@@ -92,7 +94,7 @@ def Field(
         data_invalid="true" if invalid is True else None,
         data_attr_data_invalid=invalid.if_("true") if isinstance(invalid, Signal) else None,
         cls=cn(
-            "flex w-full gap-2 group/field",
+            "w-full gap-2 group/field",
             "data-[invalid=true]:text-destructive",
             _FIELD_ORIENTATION[orientation],
             cls,
@@ -136,7 +138,8 @@ def FieldGroup(*children, cls: str = "", **kwargs) -> FT:
         *children,
         data_slot="field-group",
         cls=cn(
-            "@container/field-group flex w-full flex-col gap-5 group/field-group",
+            "@container/field-group grid w-full grid-cols-1 gap-5 group/field-group",
+            "@md/field-group:grid-cols-[auto_1fr]",
             "data-[slot=checkbox-group]:gap-3",
             "[&>[data-slot=field-group]]:gap-4",
             cls,
@@ -228,10 +231,8 @@ def FieldSeparator(*children, cls: str = "", **kwargs) -> FT:
 
 
 def FieldError(*children, signal: Signal | None = None, errors: list | None = None, cls: str = "", **kwargs):
-    _user_signal = signal
-
-    def _(*, name=None, signal=None, **_kw):
-        sig = _user_signal if _user_signal is not None else signal
+    def _(*, name=None, **_kw):
+        sig = signal or _kw.get("signal")
         if not children and errors == []:
             return None
         cs = children

--- a/registry/index.json
+++ b/registry/index.json
@@ -256,7 +256,7 @@
       "packages": [],
       "css_imports": [],
       "handlers": [],
-      "checksum": "sha256:cab1d6d1372c194dca5da83835a3ed308eabaea959b1459434ec3b098696c062"
+      "checksum": "sha256:60328e0a3492672c330ad820b845971d1be3cabb8f4458d810ee7ba1d0ffafcd"
     },
     "hover_card": {
       "name": "hover_card",


### PR DESCRIPTION
## Summary
- **Field component**: Adds accessible form field composition with validation, error propagation, orientation support, and deep autowire for composite controls
- **Dependency bump**: Updates `starhtml` minimum from `>=0.5.21` to `>=0.6.0` in both root and docs `pyproject.toml` (starlette 1.0 compatibility, built-in form handling)